### PR TITLE
add getOptions to all get requests with arrayFormat

### DIFF
--- a/src/clientWriter.ts
+++ b/src/clientWriter.ts
@@ -20,7 +20,7 @@ export async function writeClient(spec: SdkSpec, fileName: string) {
 function writeHeader(lines: string[]) {
   lines.push(`import { AxiosRequestConfig, AxiosError } from 'axios';`);
   lines.push(``);
-  lines.push(`import { SdkOptions } from './options';`);
+  lines.push(`import { GetRequestOptions, SdkOptions } from './options';`);
   lines.push(`import { SdkRequester } from './requester';`);
   lines.push(`import * as types from './types';`);
   lines.push(``);
@@ -33,8 +33,10 @@ function writeHeader(lines: string[]) {
   lines.push(`setErrorHandler(handler: (error: AxiosError) => void) {`);
   lines.push(`requester.setErrorHandler(handler);`);
   lines.push(`},`);
-  lines.push(`get(path: string, query?: object) {`);
-  lines.push(`return requester.get(path, query);`);
+  lines.push(
+    `get(path: string, query?: object, options?: GetRequestOptions) {`,
+  );
+  lines.push(`return requester.get(path, query, options);`);
   lines.push(`},`);
   lines.push(`post(path: string, data?: object) {`);
   lines.push(`return requester.post(path, data);`);
@@ -105,8 +107,10 @@ function writeMethod(spec: SdkSpec, lines: string[], method: SdkMethod) {
   const responseType = getTsType(spec, method.responseType);
   if (method.method === 'get') {
     const queryType = getTsType(spec, method.queryType);
-    lines.push(`get(query?: ${queryType}): Promise<${responseType}> {`);
-    lines.push(`return requester.get(\`${method.path}\`, query);`);
+    lines.push(
+      `get(query?: ${queryType}, options?: GetRequestOptions): Promise<${responseType}> {`,
+    );
+    lines.push(`return requester.get(\`${method.path}\`, query, options);`);
   } else {
     const requestType = getTsType(spec, method.requestType);
     const requestTypeWithDefault =

--- a/src/clientWriter.ts
+++ b/src/clientWriter.ts
@@ -34,9 +34,9 @@ function writeHeader(lines: string[]) {
   lines.push(`requester.setErrorHandler(handler);`);
   lines.push(`},`);
   lines.push(
-    `get(path: string, query?: object, options?: GetRequestOptions) {`,
+    `get(path: string, query?: object, getOptions?: GetRequestOptions) {`,
   );
-  lines.push(`return requester.get(path, query, options);`);
+  lines.push(`return requester.get(path, query, getOptions);`);
   lines.push(`},`);
   lines.push(`post(path: string, data?: object) {`);
   lines.push(`return requester.post(path, data);`);

--- a/src/tests/__snapshots__/generator.test.ts.snap
+++ b/src/tests/__snapshots__/generator.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Anonymous Types 1`] = `
 "import { AxiosRequestConfig, AxiosError } from 'axios';
 
-import { SdkOptions } from './options';
+import { GetRequestOptions, SdkOptions } from './options';
 import { SdkRequester } from './requester';
 import * as types from './types';
 
@@ -16,8 +16,8 @@ export function createSdkClient(options: SdkOptions) {
     setErrorHandler(handler: (error: AxiosError) => void) {
       requester.setErrorHandler(handler);
     },
-    get(path: string, query?: object) {
-      return requester.get(path, query);
+    get(path: string, query?: object, options?: GetRequestOptions) {
+      return requester.get(path, query, options);
     },
     post(path: string, data?: object) {
       return requester.post(path, data);
@@ -37,8 +37,11 @@ export function createSdkClient(options: SdkOptions) {
     billing: {
       invoices: {
         id: (id: number | string) => ({
-          get(query?: any): Promise<types.AgGetBillingInvoicesByIdResponse> {
-            return requester.get(\`/billing/invoices/\${id}\`, query);
+          get(
+            query?: any,
+            options?: GetRequestOptions,
+          ): Promise<types.AgGetBillingInvoicesByIdResponse> {
+            return requester.get(\`/billing/invoices/\${id}\`, query, options);
           },
         }),
       },
@@ -89,7 +92,7 @@ export interface CompanyNew {
 exports[`Basic Scenario 1`] = `
 "import { AxiosRequestConfig, AxiosError } from 'axios';
 
-import { SdkOptions } from './options';
+import { GetRequestOptions, SdkOptions } from './options';
 import { SdkRequester } from './requester';
 import * as types from './types';
 
@@ -102,8 +105,8 @@ export function createSdkClient(options: SdkOptions) {
     setErrorHandler(handler: (error: AxiosError) => void) {
       requester.setErrorHandler(handler);
     },
-    get(path: string, query?: object) {
-      return requester.get(path, query);
+    get(path: string, query?: object, options?: GetRequestOptions) {
+      return requester.get(path, query, options);
     },
     post(path: string, data?: object) {
       return requester.post(path, data);
@@ -127,8 +130,11 @@ export function createSdkClient(options: SdkOptions) {
             return requester.post(\`/companies/\${id}/archive\`, data);
           },
         },
-        get(query?: any): Promise<types.CompanyResponse> {
-          return requester.get(\`/companies/\${id}\`, query);
+        get(
+          query?: any,
+          options?: GetRequestOptions,
+        ): Promise<types.CompanyResponse> {
+          return requester.get(\`/companies/\${id}\`, query, options);
         },
         patch(
           data: types.CompanyUpdateRequest,
@@ -139,8 +145,11 @@ export function createSdkClient(options: SdkOptions) {
           return requester.delete(\`/companies/\${id}\`, data);
         },
       }),
-      get(query?: types.CompanyQuery): Promise<types.CompaniesResponse> {
-        return requester.get(\`/companies\`, query);
+      get(
+        query?: types.CompanyQuery,
+        options?: GetRequestOptions,
+      ): Promise<types.CompaniesResponse> {
+        return requester.get(\`/companies\`, query, options);
       },
       post(data: types.CompanyNewRequest): Promise<types.CompanyResponse> {
         return requester.post(\`/companies\`, data);
@@ -271,7 +280,7 @@ Object.keys(schemas).forEach((name) => {
 exports[`Dashes and Underscores 1`] = `
 "import { AxiosRequestConfig, AxiosError } from 'axios';
 
-import { SdkOptions } from './options';
+import { GetRequestOptions, SdkOptions } from './options';
 import { SdkRequester } from './requester';
 import * as types from './types';
 
@@ -284,8 +293,8 @@ export function createSdkClient(options: SdkOptions) {
     setErrorHandler(handler: (error: AxiosError) => void) {
       requester.setErrorHandler(handler);
     },
-    get(path: string, query?: object) {
-      return requester.get(path, query);
+    get(path: string, query?: object, options?: GetRequestOptions) {
+      return requester.get(path, query, options);
     },
     post(path: string, data?: object) {
       return requester.post(path, data);
@@ -304,8 +313,11 @@ export function createSdkClient(options: SdkOptions) {
     },
     user_roles: {
       role_id: (role_id: number | string) => ({
-        get(query?: any): Promise<types.AgGetUserRolesByRoleIdResponse> {
-          return requester.get(\`/user-roles/\${role_id}\`, query);
+        get(
+          query?: any,
+          options?: GetRequestOptions,
+        ): Promise<types.AgGetUserRolesByRoleIdResponse> {
+          return requester.get(\`/user-roles/\${role_id}\`, query, options);
         },
       }),
     },

--- a/src/tests/__snapshots__/generator.test.ts.snap
+++ b/src/tests/__snapshots__/generator.test.ts.snap
@@ -16,8 +16,8 @@ export function createSdkClient(options: SdkOptions) {
     setErrorHandler(handler: (error: AxiosError) => void) {
       requester.setErrorHandler(handler);
     },
-    get(path: string, query?: object, options?: GetRequestOptions) {
-      return requester.get(path, query, options);
+    get(path: string, query?: object, getOptions?: GetRequestOptions) {
+      return requester.get(path, query, getOptions);
     },
     post(path: string, data?: object) {
       return requester.post(path, data);
@@ -105,8 +105,8 @@ export function createSdkClient(options: SdkOptions) {
     setErrorHandler(handler: (error: AxiosError) => void) {
       requester.setErrorHandler(handler);
     },
-    get(path: string, query?: object, options?: GetRequestOptions) {
-      return requester.get(path, query, options);
+    get(path: string, query?: object, getOptions?: GetRequestOptions) {
+      return requester.get(path, query, getOptions);
     },
     post(path: string, data?: object) {
       return requester.post(path, data);
@@ -293,8 +293,8 @@ export function createSdkClient(options: SdkOptions) {
     setErrorHandler(handler: (error: AxiosError) => void) {
       requester.setErrorHandler(handler);
     },
-    get(path: string, query?: object, options?: GetRequestOptions) {
-      return requester.get(path, query, options);
+    get(path: string, query?: object, getOptions?: GetRequestOptions) {
+      return requester.get(path, query, getOptions);
     },
     post(path: string, data?: object) {
       return requester.post(path, data);

--- a/src/tests/requester.test.ts
+++ b/src/tests/requester.test.ts
@@ -18,4 +18,21 @@ describe('get', () => {
     });
     expect(getNock.isDone()).toBeTruthy();
   });
+
+  it('pass arrayFormat', async () => {
+    const baseUrl = 'https://example.com';
+    const requester = new SdkRequester({ baseUrl });
+    const expectedUrl = encodeURI(
+      '/path?periods[0][0]=2020-01-01&periods[0][1]=2020-01-31',
+    );
+    const getNock = nock(baseUrl).get(expectedUrl).reply(200);
+    await requester.get(
+      '/path',
+      {
+        periods: [['2020-01-01', '2020-01-31']],
+      },
+      { arrayFormat: 'indices' },
+    );
+    expect(getNock.isDone()).toBeTruthy();
+  });
 });

--- a/template/options.ts
+++ b/template/options.ts
@@ -1,3 +1,7 @@
 export interface SdkOptions {
   baseUrl: string;
 }
+
+export interface GetRequestOptions {
+  arrayFormat: 'brackets' | 'indices' | 'repeat' | 'comma' | undefined;
+}

--- a/template/requester.ts
+++ b/template/requester.ts
@@ -6,7 +6,7 @@ import axios, {
 } from 'axios';
 import qs from 'qs';
 
-import { SdkOptions } from './options';
+import { GetRequestOptions, SdkOptions } from './options';
 
 export class SdkRequester {
   private options: SdkOptions;
@@ -34,12 +34,16 @@ export class SdkRequester {
     );
   }
 
-  async get(path: string, query?: object) {
+  async get(
+    path: string,
+    query?: object,
+    options: GetRequestOptions = { arrayFormat: 'brackets' },
+  ) {
     try {
       const result = await this.axiosInstance.get(path, {
         params: query,
         paramsSerializer: (params) =>
-          qs.stringify(params, { arrayFormat: 'brackets' }),
+          qs.stringify(params, { arrayFormat: options.arrayFormat }),
         headers: this.getHeaders(),
       });
       return result.data;


### PR DESCRIPTION
Motivation: добавил возможность передать параметр с вложенным массивом через `get` запрос. Для всех `get` запросов появился дополнительный необязательный параметр, где можно указать `arrayFormat`.