### PR TITLE
PL-122 | feat: use axios with 'withCredentials = true'

### DIFF
--- a/template/options.ts
+++ b/template/options.ts
@@ -2,6 +2,7 @@ import { CancelToken } from 'axios';
 
 export interface SdkOptions {
   baseUrl: string;
+  withCredentials?: boolean;
 }
 
 export interface RequestOptions {

--- a/template/options.ts
+++ b/template/options.ts
@@ -2,7 +2,6 @@ import { CancelToken } from 'axios';
 
 export interface SdkOptions {
   baseUrl: string;
-  withCredentials?: boolean;
 }
 
 export interface RequestOptions {

--- a/template/requester.ts
+++ b/template/requester.ts
@@ -8,8 +8,6 @@ import qs from 'qs';
 
 import { RequestOptions, SdkOptions } from './options';
 
-axios.defaults.withCredentials = true;
-
 export class SdkRequester {
   private options: SdkOptions;
   private axiosInstance: AxiosInstance;
@@ -17,7 +15,10 @@ export class SdkRequester {
 
   constructor(options: SdkOptions) {
     this.options = options;
-    this.axiosInstance = axios.create({ baseURL: options.baseUrl });
+    this.axiosInstance = axios.create({
+      baseURL: options.baseUrl,
+      withCredentials: options.withCredentials,
+    });
   }
 
   setAuthToken(authToken: string | undefined) {

--- a/template/requester.ts
+++ b/template/requester.ts
@@ -16,7 +16,6 @@ export class SdkRequester {
   constructor(options: SdkOptions) {
     this.options = options;
     this.axiosInstance = axios.create({ baseURL: options.baseUrl, withCredentials: true });
-    this.axiosInstance.defaults;
   }
 
   setAuthToken(authToken: string | undefined) {

--- a/template/requester.ts
+++ b/template/requester.ts
@@ -15,10 +15,8 @@ export class SdkRequester {
 
   constructor(options: SdkOptions) {
     this.options = options;
-    this.axiosInstance = axios.create({
-      baseURL: options.baseUrl,
-      withCredentials: options.withCredentials,
-    });
+    this.axiosInstance = axios.create({ baseURL: options.baseUrl, withCredentials: true });
+    this.axiosInstance.defaults;
   }
 
   setAuthToken(authToken: string | undefined) {

--- a/template/requester.ts
+++ b/template/requester.ts
@@ -8,6 +8,8 @@ import qs from 'qs';
 
 import { RequestOptions, SdkOptions } from './options';
 
+axios.defaults.withCredentials = true;
+
 export class SdkRequester {
   private options: SdkOptions;
   private axiosInstance: AxiosInstance;


### PR DESCRIPTION
XMLHttpRequest from a different domain cannot set cookie values for their
own domain unless withCredentials is set to true before making the
request.