### PR TITLE
Add an option to generate typed schemas

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -13,7 +13,8 @@ async function main(opts, args) {
   const specFiles = args.map((arg) => path.resolve(process.cwd(), arg));
   const outDir = path.resolve(process.cwd(), opts.outDir);
   const prefix = opts.prefix;
-  await generateSdk({ specFiles, outDir, prefix });
+  const typedSchemas = opts.typedSchemas;
+  await generateSdk({ specFiles, outDir, prefix, typedSchemas });
 }
 
 program
@@ -25,6 +26,7 @@ program
     'path to a directory for a generated SDK',
   )
   .option('-p, --prefix <prefix>', 'prefix for internal schema ids')
+  .option('--typedSchemas', 'generate typed schemas')
   .arguments('<specFiles...>');
 
 program.parse(process.argv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,13 +10,19 @@ export async function generateSdk(options: {
   specFiles: string[];
   outDir: string;
   prefix?: string;
+  typedSchemas?: boolean;
 }) {
-  const { specFiles, outDir, prefix } = options;
+  const { specFiles, outDir, prefix, typedSchemas } = options;
   const spec = readSpecFromFiles(specFiles);
   copyTemplate(outDir);
   await writeClient(spec, join(outDir, 'client.ts'));
   await writeTypes(spec, join(outDir, 'types.ts'));
-  await writeSchemas({ spec, fileName: join(outDir, 'schemas.ts'), prefix });
+  await writeSchemas({
+    spec,
+    fileName: join(outDir, 'schemas.ts'),
+    prefix,
+    typedSchemas,
+  });
 }
 
 // private

--- a/src/schemaWriter.ts
+++ b/src/schemaWriter.ts
@@ -8,15 +8,22 @@ export async function writeSchemas(options: {
   spec: SdkSpec;
   fileName: string;
   prefix?: string;
+  typedSchemas?: boolean;
 }) {
-  const { spec, fileName } = options;
+  const { spec, fileName, typedSchemas } = options;
   const prefix = options.prefix || 'default';
   const definitions = clone(spec.definitions);
   const names = Object.keys(definitions).filter(isNameValid);
   const lines = [];
+  if (typedSchemas) {
+    lines.push(`import { JSONSchema6 } from 'json-schema';`);
+    lines.push(`import * as types from './types';`);
+    lines.push(`interface SdkSchema<T> extends JSONSchema6 { _type?: T }`);
+  }
   lines.push(`export const schemas = {`);
   names.forEach((name) => {
-    lines.push(`${name}: {} as any,`);
+    const schemaType = typedSchemas ? `SdkSchema<types.${name}>` : 'any';
+    lines.push(`${name}: {} as ${schemaType},`);
   });
   lines.push(`}`);
   lines.push(``);

--- a/src/schemaWriter.ts
+++ b/src/schemaWriter.ts
@@ -18,7 +18,9 @@ export async function writeSchemas(options: {
   if (typedSchemas) {
     lines.push(`import { JSONSchema6 } from 'json-schema';`);
     lines.push(`import * as types from './types';`);
-    lines.push(`interface SdkSchema<T> extends JSONSchema6 { _type?: T }`);
+    lines.push(
+      `export interface SdkSchema<T> extends JSONSchema6 { _type?: T }`,
+    );
   }
   lines.push(`export const schemas = {`);
   names.forEach((name) => {

--- a/src/tests/__snapshots__/generator.test.ts.snap
+++ b/src/tests/__snapshots__/generator.test.ts.snap
@@ -420,3 +420,32 @@ Object.keys(schemas).forEach((name) => {
 });
 "
 `;
+
+exports[`Typed Schemas 1`] = `
+"import { JSONSchema6 } from 'json-schema';
+import * as types from './types';
+export interface SdkSchema<T> extends JSONSchema6 {
+  _type?: T;
+}
+export const schemas = {
+  User: {} as SdkSchema<types.User>,
+  AgGetUsersByIdResponse: {} as SdkSchema<types.AgGetUsersByIdResponse>,
+};
+
+schemas.User = Object.assign(schemas.User, {
+  type: 'object',
+  properties: { id: { type: 'integer' }, name: { type: 'string' } },
+  required: ['id', 'name'],
+});
+
+schemas.AgGetUsersByIdResponse = Object.assign(schemas.AgGetUsersByIdResponse, {
+  type: 'object',
+  properties: { user: schemas.User },
+  required: ['user'],
+});
+
+Object.keys(schemas).forEach((name) => {
+  schemas[name as keyof typeof schemas].$id = 'default_' + name;
+});
+"
+`;

--- a/src/tests/generate.ts
+++ b/src/tests/generate.ts
@@ -10,8 +10,9 @@ export async function generate(options: {
   endpoints: string;
   models: string;
   prefix?: string;
+  typedSchemas?: boolean;
 }) {
-  const { endpoints, models, prefix } = options;
+  const { endpoints, models, prefix, typedSchemas } = options;
   const tmpDirTinyspec = tmp.dirSync({ unsafeCleanup: true });
   const tmpDirJson = tmp.dirSync({ unsafeCleanup: true });
   const tmpDirResult = tmp.dirSync({ unsafeCleanup: true });
@@ -34,6 +35,7 @@ export async function generate(options: {
     specFiles: [specPath],
     outDir: tmpDirResult.name,
     prefix,
+    typedSchemas,
   });
   const clientPath = join(tmpDirResult.name, 'client.ts');
   const typesPath = join(tmpDirResult.name, 'types.ts');

--- a/src/tests/generator.test.ts
+++ b/src/tests/generator.test.ts
@@ -125,3 +125,19 @@ it('Schema Prefix', async () => {
   });
   expect(schemasSource).toMatchSnapshot();
 });
+
+it('Typed Schemas', async () => {
+  const endpoints = `
+    GET /users/:id
+      => { user: User }
+  `;
+  const models = `
+    User { id: i, name: s }
+  `;
+  const { schemasSource } = await generate({
+    endpoints,
+    models,
+    typedSchemas: true,
+  });
+  expect(schemasSource).toMatchSnapshot();
+});


### PR DESCRIPTION
Adds a new CLI option: `--typedSchemas`. When enabled, instead of being typed like this:

```ts
export declare const schemas: {
    MySchema: any;
}
```

Schemas are typed like this:

```ts
import { JSONSchema6 } from 'json-schema';
import * as types from './types';
interface SdkSchema<T> extends JSONSchema6 {
    _type?: T;
}
export declare const schemas: {
    MySchema: SdkSchema<types.MySchema>;
}
```

With that change each schema now holds information about its underlying type.

The idea is to enable this option when generating `@osome/sdk` package. Then we can update `api` methods in `@osome/server-toolkit` to automatically infer request and response types:

```ts
// Proposed future change to server-toolkit:
export function api<TRequest, TResponseBody>(
  requestSchema: SdkSchema<TRequest>,
  responseSchema: SdkSchema<TResponseBody>,
  handler: ApiHandler<TRequest, TResponseBody>,
) { /* ... */ }
```

That makes writing controller handlers much easier, since all types are automatically inferred from schemas. Instead of this:

```ts
export const show = api<CoUserRequest, CoUserResponse>(
  schemas.CoUserRequest,
  schemas.CoUserResponse,
  /* ... */
);
```

We can just write this 🪄 

```ts
export const show = api(schemas.CoUserRequest, schemas.CoUserResponse, /* ... */);
```