### PR TITLE
Chore/add null type

### DIFF
--- a/src/tests/__snapshots__/generator.test.ts.snap
+++ b/src/tests/__snapshots__/generator.test.ts.snap
@@ -10,7 +10,7 @@ import * as types from './types';
 export function createSdkClient(options: SdkOptions) {
   const requester = new SdkRequester(options);
   return {
-    setAuthToken(authToken: string | undefined) {
+    setAuthToken(authToken: string | undefined | null) {
       requester.setAuthToken(authToken);
     },
     setErrorHandler(handler: (error: AxiosError) => void) {
@@ -112,7 +112,7 @@ import * as types from './types';
 export function createSdkClient(options: SdkOptions) {
   const requester = new SdkRequester(options);
   return {
-    setAuthToken(authToken: string | undefined) {
+    setAuthToken(authToken: string | undefined | null) {
       requester.setAuthToken(authToken);
     },
     setErrorHandler(handler: (error: AxiosError) => void) {
@@ -322,7 +322,7 @@ import * as types from './types';
 export function createSdkClient(options: SdkOptions) {
   const requester = new SdkRequester(options);
   return {
-    setAuthToken(authToken: string | undefined) {
+    setAuthToken(authToken: string | undefined | null) {
       requester.setAuthToken(authToken);
     },
     setErrorHandler(handler: (error: AxiosError) => void) {

--- a/template/requester.ts
+++ b/template/requester.ts
@@ -23,7 +23,7 @@ type Interceptors = {
 export class SdkRequester {
   private options: SdkOptions;
   private axiosInstance: AxiosInstance;
-  private authToken?: string;
+  private authToken?: string | null;
 
   constructor(options: SdkOptions) {
     this.options = options;
@@ -33,7 +33,7 @@ export class SdkRequester {
     });
   }
 
-  setAuthToken(authToken: string | undefined) {
+  setAuthToken(authToken: string | undefined | null) {
     this.authToken = authToken;
   }
 

--- a/template/sdkClient.ts
+++ b/template/sdkClient.ts
@@ -7,7 +7,7 @@ import * as types from './types';
 export function createSdkClient(options: SdkOptions) {
   const requester = new SdkRequester(options);
   return {
-    setAuthToken(authToken: string | undefined) {
+    setAuthToken(authToken: string | undefined | null) {
       requester.setAuthToken(authToken);
     },
     setErrorHandler(handler: (error: AxiosError) => void) {


### PR DESCRIPTION
Problem:
We migrated auth domain, and there is some issue with the token type. 
Tinyspec generated an anonymous response without a null type (this is a bug), although the "--add-nulls" arg was specified.

migrate auth pr: https://github.com/OsomePteLtd/sdk/pull/2173/checks


Solution:
Add null type for token.