### PR TITLE
add post process for object interfaces

### DIFF
--- a/src/tests/__snapshots__/generator.test.ts.snap
+++ b/src/tests/__snapshots__/generator.test.ts.snap
@@ -206,6 +206,7 @@ export interface Company {
   id: number;
   name: string;
   size: number;
+  meta?: {};
 }
 export interface CompanyNew {
   name: string;
@@ -259,6 +260,7 @@ schemas.Company = Object.assign(schemas.Company, {
     id: { type: 'integer' },
     name: { type: 'string' },
     size: { type: 'integer' },
+    meta: { type: 'object' },
   },
   required: ['id', 'name', 'size'],
 });
@@ -642,6 +644,10 @@ exports[`OpenAPI V3_1 Basic Scenario 2`] = `
    * nullable string
    */
   ten?: string | null;
+  /**
+   * empty object
+   */
+  meta?: {};
 }
 export type ModelWithNullableRef =
   | Model
@@ -674,6 +680,7 @@ schemas.model = Object.assign(schemas.model, {
   properties: {
     two: { description: "type 'null'", type: 'null' },
     ten: { description: 'nullable string', type: ['string', 'null'] },
+    meta: { description: 'empty object', type: 'object' },
   },
 });
 

--- a/src/tests/assets/openapi-v3_1/schema.json
+++ b/src/tests/assets/openapi-v3_1/schema.json
@@ -42,6 +42,10 @@
           "ten": {
             "description": "nullable string",
             "type": ["string", "null"]
+          },
+          "meta": {
+            "description": "empty object",
+            "type": "object"
           }
         }
       }

--- a/src/tests/generator.test.ts
+++ b/src/tests/generator.test.ts
@@ -23,7 +23,7 @@ it('Basic Scenario', async () => {
   `;
   const models = `
     SuccessResponse { success: b }
-    Company { id: i, name: s, size: i }
+    Company { id: i, name: s, size: i, meta?: o }
     CompanyNew { name: s, size: i }
     CompanyUpdate { name?: s, size?: i }
     CompanyQuery { page?: i, perPage?: i }

--- a/src/typeWriter.ts
+++ b/src/typeWriter.ts
@@ -13,15 +13,15 @@ export async function writeTypes(spec: SdkSpec, fileName: string) {
   let dtsTypes = '';
   if (isV2(openApiVersion)) {
     dtsTypes = await dtsgenerator({
-      contents: [createOpenApiSchema(definitions, 'Draft04', 'id')]
+      contents: [createOpenApiSchema(definitions, 'Draft04', 'id')],
     });
   } else if (isV3(openApiVersion)) {
     dtsTypes = await dtsgenerator({
-      contents: [createOpenApiSchema(definitions, 'Draft07', '$id')]
+      contents: [createOpenApiSchema(definitions, 'Draft07', '$id')],
     });
   } else if (isV3_1(openApiVersion)) {
     dtsTypes = await dtsgenerator({
-      contents: [createOpenApiSchema(definitions, '2020-12', '$id')]
+      contents: [createOpenApiSchema(definitions, '2020-12', '$id')],
     });
   }
   const tsTypes = dts2ts(dtsTypes);


### PR DESCRIPTION
in order to save backward compatibility for sdk, we need change how openapi-ts-sdk generates types for empty object, like this:
openapi { type: "object" } =>  ts types {}