### PR TITLE
Proxy unknown path segments to path parameter if possible

### DIFF
--- a/src/clientWriter.ts
+++ b/src/clientWriter.ts
@@ -41,7 +41,7 @@ function writeRegularNode(spec: SdkSpec, lines: string[], node: SdkNode) {
   lines.push(
     `${node.name}: ${
       pathParameterToProxy
-        ? `proxyPathPatameter('${pathParameterToProxy.slice(1, -1)}', `
+        ? `proxyPathParameter('${pathParameterToProxy.slice(1, -1)}', `
         : ''
     }{`,
   );

--- a/src/clientWriter.ts
+++ b/src/clientWriter.ts
@@ -35,10 +35,19 @@ function writeNode(spec: SdkSpec, lines: string[], node: SdkNode) {
 }
 
 function writeRegularNode(spec: SdkSpec, lines: string[], node: SdkNode) {
-  lines.push(`${node.name}: {`);
+  const pathParameterToProxy = Object.keys(node.children).find(
+    (k) => node.children[k].isFunction,
+  );
+  lines.push(
+    `${node.name}: ${
+      pathParameterToProxy
+        ? `proxyPathPatameter('${pathParameterToProxy.slice(1, -1)}', `
+        : ''
+    }{`,
+  );
   writeChildren(spec, lines, node);
   writeMethods(spec, lines, node);
-  lines.push(`},`);
+  lines.push(`}${pathParameterToProxy ? ')' : ''},`);
 }
 
 function writeFunctionNode(spec: SdkSpec, lines: string[], node: SdkNode) {

--- a/src/tests/__snapshots__/generator.test.ts.snap
+++ b/src/tests/__snapshots__/generator.test.ts.snap
@@ -74,7 +74,7 @@ export const isCancel = axios.isCancel;
 type ProxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
-> = T & T[Key] & { [key: string]: T[Key] };
+> = T & T[Key] & { [K in \`\${string}\${'id' | 'Id' | 'ID'}\`]: T[Key] };
 
 function proxyPathParameter<
   Key extends string,
@@ -85,6 +85,15 @@ function proxyPathParameter<
     get(target, p) {
       if (Object.hasOwnProperty.call(node, p)) {
         return (node as any)[p];
+      }
+
+      if (
+        typeof p === 'string' &&
+        !p.endsWith('id') &&
+        !p.endsWith('Id') &&
+        !p.endsWith('ID')
+      ) {
+        throw new Error(\`Path segment "\${p}" does not exist\`);
       }
 
       return handler;
@@ -219,7 +228,7 @@ export const isCancel = axios.isCancel;
 type ProxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
-> = T & T[Key] & { [key: string]: T[Key] };
+> = T & T[Key] & { [K in \`\${string}\${'id' | 'Id' | 'ID'}\`]: T[Key] };
 
 function proxyPathParameter<
   Key extends string,
@@ -230,6 +239,15 @@ function proxyPathParameter<
     get(target, p) {
       if (Object.hasOwnProperty.call(node, p)) {
         return (node as any)[p];
+      }
+
+      if (
+        typeof p === 'string' &&
+        !p.endsWith('id') &&
+        !p.endsWith('Id') &&
+        !p.endsWith('ID')
+      ) {
+        throw new Error(\`Path segment "\${p}" does not exist\`);
       }
 
       return handler;
@@ -416,7 +434,7 @@ export const isCancel = axios.isCancel;
 type ProxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
-> = T & T[Key] & { [key: string]: T[Key] };
+> = T & T[Key] & { [K in \`\${string}\${'id' | 'Id' | 'ID'}\`]: T[Key] };
 
 function proxyPathParameter<
   Key extends string,
@@ -427,6 +445,15 @@ function proxyPathParameter<
     get(target, p) {
       if (Object.hasOwnProperty.call(node, p)) {
         return (node as any)[p];
+      }
+
+      if (
+        typeof p === 'string' &&
+        !p.endsWith('id') &&
+        !p.endsWith('Id') &&
+        !p.endsWith('ID')
+      ) {
+        throw new Error(\`Path segment "\${p}" does not exist\`);
       }
 
       return handler;
@@ -549,7 +576,7 @@ export const isCancel = axios.isCancel;
 type ProxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
-> = T & T[Key] & { [key: string]: T[Key] };
+> = T & T[Key] & { [K in \`\${string}\${'id' | 'Id' | 'ID'}\`]: T[Key] };
 
 function proxyPathParameter<
   Key extends string,
@@ -560,6 +587,15 @@ function proxyPathParameter<
     get(target, p) {
       if (Object.hasOwnProperty.call(node, p)) {
         return (node as any)[p];
+      }
+
+      if (
+        typeof p === 'string' &&
+        !p.endsWith('id') &&
+        !p.endsWith('Id') &&
+        !p.endsWith('ID')
+      ) {
+        throw new Error(\`Path segment "\${p}" does not exist\`);
       }
 
       return handler;
@@ -719,7 +755,7 @@ export const isCancel = axios.isCancel;
 type ProxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
-> = T & T[Key] & { [key: string]: T[Key] };
+> = T & T[Key] & { [K in \`\${string}\${'id' | 'Id' | 'ID'}\`]: T[Key] };
 
 function proxyPathParameter<
   Key extends string,
@@ -730,6 +766,15 @@ function proxyPathParameter<
     get(target, p) {
       if (Object.hasOwnProperty.call(node, p)) {
         return (node as any)[p];
+      }
+
+      if (
+        typeof p === 'string' &&
+        !p.endsWith('id') &&
+        !p.endsWith('Id') &&
+        !p.endsWith('ID')
+      ) {
+        throw new Error(\`Path segment "\${p}" does not exist\`);
       }
 
       return handler;

--- a/src/tests/__snapshots__/generator.test.ts.snap
+++ b/src/tests/__snapshots__/generator.test.ts.snap
@@ -71,15 +71,25 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
+type ProxyPathParameter<
+  Key extends string,
+  T extends { [K in Key]: (...args: any) => any },
+> = T & T[Key] & { [key: string]: T[Key] };
+
 function proxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
->(key: Key, node: T): T & T[Key] {
-  return new Proxy(node, {
-    apply(target, thisArg, argArray) {
-      return Reflect.apply(node[key], thisArg, argArray);
+>(key: Key, node: T): ProxyPathParameter<Key, T> {
+  const handler = node[key];
+  return new Proxy(handler, {
+    get(target, p) {
+      if (Object.hasOwnProperty.call(node, p)) {
+        return (node as any)[p];
+      }
+
+      return handler;
     },
-  }) as T & T[Key];
+  }) as ProxyPathParameter<Key, T>;
 }
 "
 `;
@@ -206,15 +216,25 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
+type ProxyPathParameter<
+  Key extends string,
+  T extends { [K in Key]: (...args: any) => any },
+> = T & T[Key] & { [key: string]: T[Key] };
+
 function proxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
->(key: Key, node: T): T & T[Key] {
-  return new Proxy(node, {
-    apply(target, thisArg, argArray) {
-      return Reflect.apply(node[key], thisArg, argArray);
+>(key: Key, node: T): ProxyPathParameter<Key, T> {
+  const handler = node[key];
+  return new Proxy(handler, {
+    get(target, p) {
+      if (Object.hasOwnProperty.call(node, p)) {
+        return (node as any)[p];
+      }
+
+      return handler;
     },
-  }) as T & T[Key];
+  }) as ProxyPathParameter<Key, T>;
 }
 "
 `;
@@ -393,15 +413,25 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
+type ProxyPathParameter<
+  Key extends string,
+  T extends { [K in Key]: (...args: any) => any },
+> = T & T[Key] & { [key: string]: T[Key] };
+
 function proxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
->(key: Key, node: T): T & T[Key] {
-  return new Proxy(node, {
-    apply(target, thisArg, argArray) {
-      return Reflect.apply(node[key], thisArg, argArray);
+>(key: Key, node: T): ProxyPathParameter<Key, T> {
+  const handler = node[key];
+  return new Proxy(handler, {
+    get(target, p) {
+      if (Object.hasOwnProperty.call(node, p)) {
+        return (node as any)[p];
+      }
+
+      return handler;
     },
-  }) as T & T[Key];
+  }) as ProxyPathParameter<Key, T>;
 }
 "
 `;
@@ -516,15 +546,25 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
+type ProxyPathParameter<
+  Key extends string,
+  T extends { [K in Key]: (...args: any) => any },
+> = T & T[Key] & { [key: string]: T[Key] };
+
 function proxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
->(key: Key, node: T): T & T[Key] {
-  return new Proxy(node, {
-    apply(target, thisArg, argArray) {
-      return Reflect.apply(node[key], thisArg, argArray);
+>(key: Key, node: T): ProxyPathParameter<Key, T> {
+  const handler = node[key];
+  return new Proxy(handler, {
+    get(target, p) {
+      if (Object.hasOwnProperty.call(node, p)) {
+        return (node as any)[p];
+      }
+
+      return handler;
     },
-  }) as T & T[Key];
+  }) as ProxyPathParameter<Key, T>;
 }
 "
 `;
@@ -676,15 +716,25 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
+type ProxyPathParameter<
+  Key extends string,
+  T extends { [K in Key]: (...args: any) => any },
+> = T & T[Key] & { [key: string]: T[Key] };
+
 function proxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
->(key: Key, node: T): T & T[Key] {
-  return new Proxy(node, {
-    apply(target, thisArg, argArray) {
-      return Reflect.apply(node[key], thisArg, argArray);
+>(key: Key, node: T): ProxyPathParameter<Key, T> {
+  const handler = node[key];
+  return new Proxy(handler, {
+    get(target, p) {
+      if (Object.hasOwnProperty.call(node, p)) {
+        return (node as any)[p];
+      }
+
+      return handler;
     },
-  }) as T & T[Key];
+  }) as ProxyPathParameter<Key, T>;
 }
 "
 `;

--- a/src/tests/__snapshots__/generator.test.ts.snap
+++ b/src/tests/__snapshots__/generator.test.ts.snap
@@ -40,7 +40,7 @@ export function createSdkClient(options: SdkOptions) {
       return requester.request(options);
     },
     billing: {
-      invoices: proxyPathPatameter('id', {
+      invoices: proxyPathParameter('id', {
         id: (id: number | string) => ({
           get(
             query?: any,
@@ -152,7 +152,7 @@ export function createSdkClient(options: SdkOptions) {
     request(options: AxiosRequestConfig) {
       return requester.request(options);
     },
-    companies: proxyPathPatameter('id', {
+    companies: proxyPathParameter('id', {
       id: (id: number | string) => ({
         archive: {
           post(
@@ -375,7 +375,7 @@ export function createSdkClient(options: SdkOptions) {
     request(options: AxiosRequestConfig) {
       return requester.request(options);
     },
-    user_roles: proxyPathPatameter('role_id', {
+    user_roles: proxyPathParameter('role_id', {
       role_id: (role_id: number | string) => ({
         get(
           query?: any,
@@ -486,7 +486,7 @@ export function createSdkClient(options: SdkOptions) {
     request(options: AxiosRequestConfig) {
       return requester.request(options);
     },
-    pets: proxyPathPatameter('id', {
+    pets: proxyPathParameter('id', {
       id: (id: number | string) => ({
         get(query?: any, requestOptions?: RequestOptions): Promise<types.Pet> {
           return requester.get(\`/pets/\${id}\`, query, requestOptions);

--- a/src/tests/__snapshots__/generator.test.ts.snap
+++ b/src/tests/__snapshots__/generator.test.ts.snap
@@ -40,7 +40,7 @@ export function createSdkClient(options: SdkOptions) {
       return requester.request(options);
     },
     billing: {
-      invoices: {
+      invoices: proxyPathPatameter('id', {
         id: (id: number | string) => ({
           get(
             query?: any,
@@ -53,7 +53,7 @@ export function createSdkClient(options: SdkOptions) {
             );
           },
         }),
-      },
+      }),
     },
     companies: {
       post(
@@ -70,6 +70,17 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
+
+function proxifyPathParameter<
+  Key extends string,
+  T extends { [K in Key]: (...args: any) => any },
+>(key: Key, node: T): T & T[Key] {
+  return new Proxy(node, {
+    apply(target, thisArg, argArray) {
+      return Reflect.apply(node[key], thisArg, argArray);
+    },
+  }) as T & T[Key];
+}
 "
 `;
 
@@ -141,7 +152,7 @@ export function createSdkClient(options: SdkOptions) {
     request(options: AxiosRequestConfig) {
       return requester.request(options);
     },
-    companies: {
+    companies: proxyPathPatameter('id', {
       id: (id: number | string) => ({
         archive: {
           post(
@@ -186,7 +197,7 @@ export function createSdkClient(options: SdkOptions) {
       ): Promise<types.CompanyResponse> {
         return requester.post(\`/companies\`, data, requestOptions);
       },
-    },
+    }),
   };
 }
 
@@ -194,6 +205,17 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
+
+function proxifyPathParameter<
+  Key extends string,
+  T extends { [K in Key]: (...args: any) => any },
+>(key: Key, node: T): T & T[Key] {
+  return new Proxy(node, {
+    apply(target, thisArg, argArray) {
+      return Reflect.apply(node[key], thisArg, argArray);
+    },
+  }) as T & T[Key];
+}
 "
 `;
 
@@ -353,7 +375,7 @@ export function createSdkClient(options: SdkOptions) {
     request(options: AxiosRequestConfig) {
       return requester.request(options);
     },
-    user_roles: {
+    user_roles: proxyPathPatameter('role_id', {
       role_id: (role_id: number | string) => ({
         get(
           query?: any,
@@ -362,7 +384,7 @@ export function createSdkClient(options: SdkOptions) {
           return requester.get(\`/user-roles/\${role_id}\`, query, requestOptions);
         },
       }),
-    },
+    }),
   };
 }
 
@@ -370,6 +392,17 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
+
+function proxifyPathParameter<
+  Key extends string,
+  T extends { [K in Key]: (...args: any) => any },
+>(key: Key, node: T): T & T[Key] {
+  return new Proxy(node, {
+    apply(target, thisArg, argArray) {
+      return Reflect.apply(node[key], thisArg, argArray);
+    },
+  }) as T & T[Key];
+}
 "
 `;
 
@@ -453,7 +486,7 @@ export function createSdkClient(options: SdkOptions) {
     request(options: AxiosRequestConfig) {
       return requester.request(options);
     },
-    pets: {
+    pets: proxyPathPatameter('id', {
       id: (id: number | string) => ({
         get(query?: any, requestOptions?: RequestOptions): Promise<types.Pet> {
           return requester.get(\`/pets/\${id}\`, query, requestOptions);
@@ -474,7 +507,7 @@ export function createSdkClient(options: SdkOptions) {
       ): Promise<types.Pet> {
         return requester.post(\`/pets\`, data, requestOptions);
       },
-    },
+    }),
   };
 }
 
@@ -482,6 +515,17 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
+
+function proxifyPathParameter<
+  Key extends string,
+  T extends { [K in Key]: (...args: any) => any },
+>(key: Key, node: T): T & T[Key] {
+  return new Proxy(node, {
+    apply(target, thisArg, argArray) {
+      return Reflect.apply(node[key], thisArg, argArray);
+    },
+  }) as T & T[Key];
+}
 "
 `;
 
@@ -631,6 +675,17 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
+
+function proxifyPathParameter<
+  Key extends string,
+  T extends { [K in Key]: (...args: any) => any },
+>(key: Key, node: T): T & T[Key] {
+  return new Proxy(node, {
+    apply(target, thisArg, argArray) {
+      return Reflect.apply(node[key], thisArg, argArray);
+    },
+  }) as T & T[Key];
+}
 "
 `;
 

--- a/src/tests/__snapshots__/generator.test.ts.snap
+++ b/src/tests/__snapshots__/generator.test.ts.snap
@@ -71,7 +71,7 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-function proxifyPathParameter<
+function proxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
 >(key: Key, node: T): T & T[Key] {
@@ -206,7 +206,7 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-function proxifyPathParameter<
+function proxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
 >(key: Key, node: T): T & T[Key] {
@@ -393,7 +393,7 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-function proxifyPathParameter<
+function proxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
 >(key: Key, node: T): T & T[Key] {
@@ -516,7 +516,7 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-function proxifyPathParameter<
+function proxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
 >(key: Key, node: T): T & T[Key] {
@@ -676,7 +676,7 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-function proxifyPathParameter<
+function proxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
 >(key: Key, node: T): T & T[Key] {

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -1,0 +1,64 @@
+import nock from 'nock';
+import { join } from 'path';
+import tmp from 'tmp';
+
+import { generateSdk } from '..';
+
+let tmpDirResult: tmp.DirResult;
+
+beforeAll(async () => {
+  tmpDirResult = tmp.dirSync({ tmpdir: __dirname, unsafeCleanup: true });
+  await generateSdk({
+    specFiles: [join(__dirname, 'assets', 'openapi-v3', 'petstore.json')],
+    outDir: tmpDirResult.name,
+  });
+});
+
+afterAll(() => {
+  tmpDirResult.removeCallback();
+});
+
+it('works', () => {
+  return import(join(tmpDirResult.name, 'client.ts'))
+    .then(async ({ createSdkClient }) => {
+      const baseUrl = 'https://example.com';
+      const expectedUrl = '/pets/1';
+      const getNock = nock(baseUrl).get(expectedUrl).reply(200);
+      const sdkClient = createSdkClient({ baseUrl });
+
+      await sdkClient.pets.id(1).get();
+
+      expect(getNock.isDone()).toBeTruthy();
+    })
+    .catch((e) => console.error(e));
+});
+
+it('supports proxied path parameters', () => {
+  return import(join(tmpDirResult.name, 'client.ts')).then(
+    async ({ createSdkClient }) => {
+      const baseUrl = 'https://example.com';
+      const expectedUrl = '/pets/1';
+      const getNock = nock(baseUrl).get(expectedUrl).reply(200);
+      const sdkClient = createSdkClient({ baseUrl });
+
+      await sdkClient.pets(1).get();
+
+      expect(getNock.isDone()).toBeTruthy();
+    },
+  );
+});
+
+it('treats any unknown path segment as path parameter', () => {
+  return import(join(tmpDirResult.name, 'client.ts')).then(
+    async ({ createSdkClient }) => {
+      const baseUrl = 'https://example.com';
+      const expectedUrl = '/pets/1';
+      const getNock = nock(baseUrl).get(expectedUrl).reply(200);
+      const sdkClient = createSdkClient({ baseUrl });
+
+      await sdkClient.pets.petId(1).get();
+
+      expect(getNock.isDone()).toBeTruthy();
+    },
+  );
+});

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -48,7 +48,7 @@ it('supports proxied path parameters', () => {
   );
 });
 
-it('treats any unknown path segment as path parameter', () => {
+it('treats any whitelisted unknown path segment as path parameter', () => {
   return import(join(tmpDirResult.name, 'client.ts')).then(
     async ({ createSdkClient }) => {
       const baseUrl = 'https://example.com';
@@ -74,6 +74,19 @@ it("doesn't treat known path segments as path parameters", () => {
       await sdkClient.pets.get(1);
 
       expect(getNock.isDone()).toBeTruthy();
+    },
+  );
+});
+
+it('throws on not whitelisted unknown path segments', () => {
+  return import(join(tmpDirResult.name, 'client.ts')).then(
+    async ({ createSdkClient }) => {
+      const baseUrl = 'https://example.com';
+      const sdkClient = createSdkClient({ baseUrl });
+
+      expect(() => sdkClient.pets.notWhitelisted(1).get()).toThrowError(
+        'Path segment "notWhitelisted" does not exist',
+      );
     },
   );
 });

--- a/src/tests/client.test.ts
+++ b/src/tests/client.test.ts
@@ -62,3 +62,18 @@ it('treats any unknown path segment as path parameter', () => {
     },
   );
 });
+
+it("doesn't treat known path segments as path parameters", () => {
+  return import(join(tmpDirResult.name, 'client.ts')).then(
+    async ({ createSdkClient }) => {
+      const baseUrl = 'https://example.com';
+      const expectedUrl = '/pets';
+      const getNock = nock(baseUrl).get(expectedUrl).reply(200);
+      const sdkClient = createSdkClient({ baseUrl });
+
+      await sdkClient.pets.get(1);
+
+      expect(getNock.isDone()).toBeTruthy();
+    },
+  );
+});

--- a/template/sdkClient.ts
+++ b/template/sdkClient.ts
@@ -48,7 +48,7 @@ export const isCancel = axios.isCancel;
 type ProxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
-> = T & T[Key] & { [K in `${string}${'id' | 'Id' | 'ID'}`]: T[Key] };
+> = T & T[Key] & { [K in \`\${string}\${'id' | 'Id' | 'ID'}\`]: T[Key] };
 
 function proxyPathParameter<
   Key extends string,
@@ -67,7 +67,7 @@ function proxyPathParameter<
         !p.endsWith('Id') &&
         !p.endsWith('ID')
       ) {
-        throw new Error(`Path segment "${p}" does not exist`);
+        throw new Error(\`Path segment "\${p}" does not exist\`);
       }
 
       return handler;

--- a/template/sdkClient.ts
+++ b/template/sdkClient.ts
@@ -44,3 +44,14 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
+
+function proxyPathParameter<
+  Key extends string,
+  T extends { [K in Key]: (...args: any) => any },
+>(key: Key, node: T): T & T[Key] {
+  return new Proxy(node, {
+    apply(target, thisArg, argArray) {
+      return Reflect.apply(node[key], thisArg, argArray);
+    },
+  }) as T & T[Key];
+}

--- a/template/sdkClient.ts
+++ b/template/sdkClient.ts
@@ -48,7 +48,7 @@ export const isCancel = axios.isCancel;
 type ProxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
-> = T & T[Key] & { [key: string]: T[Key] };
+> = T & T[Key] & { [K in `${string}${'id' | 'Id' | 'ID'}`]: T[Key] };
 
 function proxyPathParameter<
   Key extends string,
@@ -59,6 +59,15 @@ function proxyPathParameter<
     get(target, p) {
       if (Object.hasOwnProperty.call(node, p)) {
         return (node as any)[p];
+      }
+
+      if (
+        typeof p === 'string' &&
+        !p.endsWith('id') &&
+        !p.endsWith('Id') &&
+        !p.endsWith('ID')
+      ) {
+        throw new Error(`Path segment "${p}" does not exist`);
       }
 
       return handler;

--- a/template/sdkClient.ts
+++ b/template/sdkClient.ts
@@ -45,13 +45,23 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
+type ProxyPathParameter<
+  Key extends string,
+  T extends { [K in Key]: (...args: any) => any },
+> = T & T[Key] & { [key: string]: T[Key] };
+
 function proxyPathParameter<
   Key extends string,
   T extends { [K in Key]: (...args: any) => any },
->(key: Key, node: T): T & T[Key] {
-  return new Proxy(node, {
-    apply(target, thisArg, argArray) {
-      return Reflect.apply(node[key], thisArg, argArray);
+>(key: Key, node: T): ProxyPathParameter<Key, T> {
+  const handler = node[key];
+  return new Proxy(handler, {
+    get(target, p) {
+      if (Object.hasOwnProperty.call(node, p)) {
+        return (node as any)[p];
+      }
+
+      return handler;
     },
-  }) as T & T[Key];
+  }) as ProxyPathParameter<Key, T>;
 }


### PR DESCRIPTION
Given the spec:

```jsonc
{
  "openapi": "3.0.0",
  "paths": {
    "/pets/{id}": {
      "get": { /* ... */ },
      "delete": { /* ... */ },
    }
  }
}
```

Generates SDK client that allows all of the following calls:

```ts
client.pets.id(1).get();
client.pets.id(1).delete();
client.pets(1).get();       // New!
client.pets(1).delete();    // New!
```

It does that by proxying calls on a spec "node" to the first found path parameter method.