### PR TITLE
Merge differently named path parameters

### DIFF
--- a/src/clientWriter.ts
+++ b/src/clientWriter.ts
@@ -55,7 +55,7 @@ function writeRegularNode(spec: SdkSpec, lines: string[], node: SdkNode) {
 }
 
 function writeFunctionNode(spec: SdkSpec, lines: string[], node: SdkNode) {
-  lines.push(`${node.name}: (${node.name}: number | string) => ({`);
+  lines.push(`pathParameter: (${node.name}: number | string) => ({`);
   writeChildren(spec, lines, node);
   writeMethods(spec, lines, node);
   lines.push(`}),`);

--- a/src/clientWriter.ts
+++ b/src/clientWriter.ts
@@ -1,9 +1,10 @@
 import fs from 'fs';
-import { loadTemplate } from './clientTemplateLoader';
+import { merge } from 'lodash';
 
+import { loadTemplate } from './clientTemplateLoader';
 import { format } from './formatter';
 import { isNameValid } from './helpers';
-import { SdkMethod, SdkNode, SdkSpec } from './specReader';
+import { SdkFunctionNode, SdkMethod, SdkNode, SdkSpec } from './specReader';
 
 export async function writeClient(spec: SdkSpec, fileName: string) {
   const lines: string[] = [];
@@ -35,25 +36,23 @@ function writeNode(spec: SdkSpec, lines: string[], node: SdkNode) {
 }
 
 function writeRegularNode(spec: SdkSpec, lines: string[], node: SdkNode) {
-  const pathParametersToProxy = Object.keys(node.children).filter(
-    (k) => node.children[k].isFunction,
+  const pathParameter = Object.values(node.children).find(
+    (node) => node.isFunction,
   );
-  const pathParametersToProxyArray =
-    pathParametersToProxy.length > 0
-      ? `[${pathParametersToProxy
-          .map((p) => `'${p.slice(1, -1)}'`)
-          .join(', ')}] as const`
-      : null;
+  const pathParameterNames = pathParameter
+    ? `[${(pathParameter as SdkFunctionNode).aliases
+        .map((name) => `'${name}'`)
+        .join(', ')}] as const`
+    : null;
+
   lines.push(
     `${node.name}: ${
-      pathParametersToProxyArray
-        ? `proxyPathParameter(${pathParametersToProxyArray}, `
-        : ''
+      pathParameterNames ? `withPathParameters(${pathParameterNames}, ` : ''
     }{`,
   );
   writeChildren(spec, lines, node);
   writeMethods(spec, lines, node);
-  lines.push(`}${pathParametersToProxyArray ? ')' : ''},`);
+  lines.push(`}${pathParameterNames ? ')' : ''},`);
 }
 
 function writeFunctionNode(spec: SdkSpec, lines: string[], node: SdkNode) {

--- a/src/clientWriter.ts
+++ b/src/clientWriter.ts
@@ -35,19 +35,25 @@ function writeNode(spec: SdkSpec, lines: string[], node: SdkNode) {
 }
 
 function writeRegularNode(spec: SdkSpec, lines: string[], node: SdkNode) {
-  const pathParameterToProxy = Object.keys(node.children).find(
+  const pathParametersToProxy = Object.keys(node.children).filter(
     (k) => node.children[k].isFunction,
   );
+  const pathParametersToProxyArray =
+    pathParametersToProxy.length > 0
+      ? `[${pathParametersToProxy
+          .map((p) => `'${p.slice(1, -1)}'`)
+          .join(', ')}] as const`
+      : null;
   lines.push(
     `${node.name}: ${
-      pathParameterToProxy
-        ? `proxyPathParameter('${pathParameterToProxy.slice(1, -1)}', `
+      pathParametersToProxyArray
+        ? `proxyPathParameter(${pathParametersToProxyArray}, `
         : ''
     }{`,
   );
   writeChildren(spec, lines, node);
   writeMethods(spec, lines, node);
-  lines.push(`}${pathParameterToProxy ? ')' : ''},`);
+  lines.push(`}${pathParametersToProxyArray ? ')' : ''},`);
 }
 
 function writeFunctionNode(spec: SdkSpec, lines: string[], node: SdkNode) {

--- a/src/clientWriter.ts
+++ b/src/clientWriter.ts
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import { merge } from 'lodash';
 
 import { loadTemplate } from './clientTemplateLoader';
 import { format } from './formatter';

--- a/src/specReader.ts
+++ b/src/specReader.ts
@@ -99,9 +99,10 @@ function addUrl(
   }
   const [head, ...tail] = path;
   const { key, isFunction, name } = parsePathSegment(head);
-  const node = (parent.children[key] ??= isFunction
+  parent.children[key] ??= isFunction
     ? createFunctionNode(parent, name)
-    : createRegularNode(parent, name));
+    : createRegularNode(parent, name);
+  const node = parent.children[key];
   if (node.isFunction && !node.aliases.includes(name)) {
     node.aliases.push(name);
   }

--- a/src/specReader.ts
+++ b/src/specReader.ts
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import { isFunction } from 'lodash';
 
 import { pascalCase } from './helpers';
 import {

--- a/src/specReader.ts
+++ b/src/specReader.ts
@@ -152,7 +152,7 @@ function createRegularNode(parent: SdkNode, name: string): SdkRegularNode {
 function createFunctionNode(parent: SdkNode, name: string): SdkFunctionNode {
   return {
     parent,
-    name: 'pathParameter',
+    name,
     aliases: [name],
     isFunction: true,
     children: {},

--- a/src/tests/__snapshots__/generator.test.ts.snap
+++ b/src/tests/__snapshots__/generator.test.ts.snap
@@ -41,13 +41,13 @@ export function createSdkClient(options: SdkOptions) {
     },
     billing: {
       invoices: withPathParameters(['id'] as const, {
-        pathParameter: (pathParameter: number | string) => ({
+        pathParameter: (id: number | string) => ({
           get(
             query?: any,
             requestOptions?: RequestOptions,
-          ): Promise<types.AgGetBillingInvoicesByPathParameterResponse> {
+          ): Promise<types.AgGetBillingInvoicesByIdResponse> {
             return requester.get(
-              \`/billing/invoices/\${pathParameter}\`,
+              \`/billing/invoices/\${id}\`,
               query,
               requestOptions,
             );
@@ -101,7 +101,7 @@ function withPathParameters<
 `;
 
 exports[`Anonymous Types 2`] = `
-"export interface AgGetBillingInvoicesByPathParameterResponse {
+"export interface AgGetBillingInvoicesByIdResponse {
   invoice: {
     id: number;
   };
@@ -169,14 +169,14 @@ export function createSdkClient(options: SdkOptions) {
       return requester.request(options);
     },
     companies: withPathParameters(['id'] as const, {
-      pathParameter: (pathParameter: number | string) => ({
+      pathParameter: (id: number | string) => ({
         archive: {
           post(
             data: any = {},
             requestOptions?: RequestOptions,
           ): Promise<types.SuccessResponse> {
             return requester.post(
-              \`/companies/\${pathParameter}/archive\`,
+              \`/companies/\${id}/archive\`,
               data,
               requestOptions,
             );
@@ -186,31 +186,19 @@ export function createSdkClient(options: SdkOptions) {
           query?: any,
           requestOptions?: RequestOptions,
         ): Promise<types.CompanyResponse> {
-          return requester.get(
-            \`/companies/\${pathParameter}\`,
-            query,
-            requestOptions,
-          );
+          return requester.get(\`/companies/\${id}\`, query, requestOptions);
         },
         patch(
           data: types.CompanyUpdateRequest,
           requestOptions?: RequestOptions,
         ): Promise<types.CompanyResponse> {
-          return requester.patch(
-            \`/companies/\${pathParameter}\`,
-            data,
-            requestOptions,
-          );
+          return requester.patch(\`/companies/\${id}\`, data, requestOptions);
         },
         delete(
           data: any = {},
           requestOptions?: RequestOptions,
         ): Promise<types.SuccessResponse> {
-          return requester.delete(
-            \`/companies/\${pathParameter}\`,
-            data,
-            requestOptions,
-          );
+          return requester.delete(\`/companies/\${id}\`, data, requestOptions);
         },
       }),
       get(
@@ -420,16 +408,12 @@ export function createSdkClient(options: SdkOptions) {
       return requester.request(options);
     },
     user_roles: withPathParameters(['role_id'] as const, {
-      pathParameter: (pathParameter: number | string) => ({
+      pathParameter: (role_id: number | string) => ({
         get(
           query?: any,
           requestOptions?: RequestOptions,
-        ): Promise<types.AgGetUserRolesByPathParameterResponse> {
-          return requester.get(
-            \`/user-roles/\${pathParameter}\`,
-            query,
-            requestOptions,
-          );
+        ): Promise<types.AgGetUserRolesByRoleIdResponse> {
+          return requester.get(\`/user-roles/\${role_id}\`, query, requestOptions);
         },
       }),
     }),
@@ -471,7 +455,7 @@ function withPathParameters<
 `;
 
 exports[`Dashes and Underscores 2`] = `
-"export interface AgGetUserRolesByPathParameterResponse {
+"export interface AgGetUserRolesByRoleIdResponse {
   user_role: UserRole;
 }
 export interface UserRole {
@@ -551,25 +535,17 @@ export function createSdkClient(options: SdkOptions) {
       return requester.request(options);
     },
     pets: withPathParameters(['id', 'petId'] as const, {
-      pathParameter: (pathParameter: number | string) => ({
+      pathParameter: (id: number | string) => ({
         siblings: {
           get(query?: any, requestOptions?: RequestOptions): Promise<any> {
-            return requester.get(
-              \`/pets/\${pathParameter}/siblings\`,
-              query,
-              requestOptions,
-            );
+            return requester.get(\`/pets/\${id}/siblings\`, query, requestOptions);
           },
         },
         get(query?: any, requestOptions?: RequestOptions): Promise<types.Pet> {
-          return requester.get(\`/pets/\${pathParameter}\`, query, requestOptions);
+          return requester.get(\`/pets/\${id}\`, query, requestOptions);
         },
         delete(data: any = {}, requestOptions?: RequestOptions): Promise<any> {
-          return requester.delete(
-            \`/pets/\${pathParameter}\`,
-            data,
-            requestOptions,
-          );
+          return requester.delete(\`/pets/\${id}\`, data, requestOptions);
         },
       }),
       get(
@@ -857,7 +833,7 @@ Object.keys(schemas).forEach((name) => {
 exports[`Schema Prefix 1`] = `
 "export const schemas = {
   User: {} as any,
-  AgGetUsersByPathParameterResponse: {} as any,
+  AgGetUsersByIdResponse: {} as any,
 };
 
 schemas.User = Object.assign(schemas.User, {
@@ -866,10 +842,11 @@ schemas.User = Object.assign(schemas.User, {
   required: ['id', 'name'],
 });
 
-schemas.AgGetUsersByPathParameterResponse = Object.assign(
-  schemas.AgGetUsersByPathParameterResponse,
-  { type: 'object', properties: { user: schemas.User }, required: ['user'] },
-);
+schemas.AgGetUsersByIdResponse = Object.assign(schemas.AgGetUsersByIdResponse, {
+  type: 'object',
+  properties: { user: schemas.User },
+  required: ['user'],
+});
 
 Object.keys(schemas).forEach((name) => {
   schemas[name as keyof typeof schemas].$id = 'myFancyPrefix_' + name;
@@ -885,8 +862,7 @@ export interface SdkSchema<T> extends JSONSchema6 {
 }
 export const schemas = {
   User: {} as SdkSchema<types.User>,
-  AgGetUsersByPathParameterResponse:
-    {} as SdkSchema<types.AgGetUsersByPathParameterResponse>,
+  AgGetUsersByIdResponse: {} as SdkSchema<types.AgGetUsersByIdResponse>,
 };
 
 schemas.User = Object.assign(schemas.User, {
@@ -895,10 +871,11 @@ schemas.User = Object.assign(schemas.User, {
   required: ['id', 'name'],
 });
 
-schemas.AgGetUsersByPathParameterResponse = Object.assign(
-  schemas.AgGetUsersByPathParameterResponse,
-  { type: 'object', properties: { user: schemas.User }, required: ['user'] },
-);
+schemas.AgGetUsersByIdResponse = Object.assign(schemas.AgGetUsersByIdResponse, {
+  type: 'object',
+  properties: { user: schemas.User },
+  required: ['user'],
+});
 
 Object.keys(schemas).forEach((name) => {
   schemas[name as keyof typeof schemas].$id = 'default_' + name;

--- a/src/tests/__snapshots__/generator.test.ts.snap
+++ b/src/tests/__snapshots__/generator.test.ts.snap
@@ -40,7 +40,7 @@ export function createSdkClient(options: SdkOptions) {
       return requester.request(options);
     },
     billing: {
-      invoices: proxyPathParameter('id', {
+      invoices: proxyPathParameter(['id'] as const, {
         id: (id: number | string) => ({
           get(
             query?: any,
@@ -71,34 +71,51 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-type ProxyPathParameter<
-  Key extends string,
-  T extends { [K in Key]: (...args: any) => any },
-> = T & T[Key] & { [K in \`\${string}\${'id' | 'Id' | 'ID'}\`]: T[Key] };
+type ProxyPathParameters<
+  Keys extends readonly string[],
+  Spec extends {
+    [K in Keys[number]]: (...args: any) => any;
+  },
+> = Omit<Spec, Keys[number]> &
+  MergePathParameters<Keys, Spec> & {
+    [K in Keys[number]]: MergePathParameters<Keys, Spec>;
+  };
+
+type MergePathParameters<
+  Keys extends readonly string[],
+  Spec extends {
+    [K in Keys[number]]: (...args: any) => any;
+  },
+> = (
+  ...args: Parameters<Spec[Keys[0]]>
+) => (Keys[0] extends keyof Spec ? ReturnType<Spec[Keys[0]]> : {}) &
+  (Keys[1] extends keyof Spec ? ReturnType<Spec[Keys[1]]> : {}) &
+  (Keys[2] extends keyof Spec ? ReturnType<Spec[Keys[2]]> : {});
 
 function proxyPathParameter<
-  Key extends string,
-  T extends { [K in Key]: (...args: any) => any },
->(key: Key, node: T): ProxyPathParameter<Key, T> {
-  const handler = node[key];
+  Keys extends readonly string[],
+  Spec extends {
+    [K in Keys[number]]: (...args: any) => any;
+  },
+>(keys: Keys, spec: Spec): ProxyPathParameters<Keys, Spec> {
+  const handler = (...args: unknown[]) => {
+    const specs = keys.map((k: Keys[number]) => spec[k](...args));
+    // TODO: deep merge here
+    return Object.assign({}, ...specs);
+  };
   return new Proxy(handler, {
     get(target, p) {
-      if (Object.hasOwnProperty.call(node, p)) {
-        return (node as any)[p];
+      if (typeof p === 'string' && keys.includes(p)) {
+        return handler;
       }
 
-      if (
-        typeof p === 'string' &&
-        !p.endsWith('id') &&
-        !p.endsWith('Id') &&
-        !p.endsWith('ID')
-      ) {
-        throw new Error(\`Path segment "\${p}" does not exist\`);
+      if (Object.hasOwnProperty.call(spec, p)) {
+        return (spec as any)[p];
       }
 
-      return handler;
+      throw new Error(\`Path segment "\${p.toString()}" does not exist\`);
     },
-  }) as ProxyPathParameter<Key, T>;
+  }) as any;
 }
 "
 `;
@@ -171,7 +188,7 @@ export function createSdkClient(options: SdkOptions) {
     request(options: AxiosRequestConfig) {
       return requester.request(options);
     },
-    companies: proxyPathParameter('id', {
+    companies: proxyPathParameter(['id'] as const, {
       id: (id: number | string) => ({
         archive: {
           post(
@@ -225,34 +242,51 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-type ProxyPathParameter<
-  Key extends string,
-  T extends { [K in Key]: (...args: any) => any },
-> = T & T[Key] & { [K in \`\${string}\${'id' | 'Id' | 'ID'}\`]: T[Key] };
+type ProxyPathParameters<
+  Keys extends readonly string[],
+  Spec extends {
+    [K in Keys[number]]: (...args: any) => any;
+  },
+> = Omit<Spec, Keys[number]> &
+  MergePathParameters<Keys, Spec> & {
+    [K in Keys[number]]: MergePathParameters<Keys, Spec>;
+  };
+
+type MergePathParameters<
+  Keys extends readonly string[],
+  Spec extends {
+    [K in Keys[number]]: (...args: any) => any;
+  },
+> = (
+  ...args: Parameters<Spec[Keys[0]]>
+) => (Keys[0] extends keyof Spec ? ReturnType<Spec[Keys[0]]> : {}) &
+  (Keys[1] extends keyof Spec ? ReturnType<Spec[Keys[1]]> : {}) &
+  (Keys[2] extends keyof Spec ? ReturnType<Spec[Keys[2]]> : {});
 
 function proxyPathParameter<
-  Key extends string,
-  T extends { [K in Key]: (...args: any) => any },
->(key: Key, node: T): ProxyPathParameter<Key, T> {
-  const handler = node[key];
+  Keys extends readonly string[],
+  Spec extends {
+    [K in Keys[number]]: (...args: any) => any;
+  },
+>(keys: Keys, spec: Spec): ProxyPathParameters<Keys, Spec> {
+  const handler = (...args: unknown[]) => {
+    const specs = keys.map((k: Keys[number]) => spec[k](...args));
+    // TODO: deep merge here
+    return Object.assign({}, ...specs);
+  };
   return new Proxy(handler, {
     get(target, p) {
-      if (Object.hasOwnProperty.call(node, p)) {
-        return (node as any)[p];
+      if (typeof p === 'string' && keys.includes(p)) {
+        return handler;
       }
 
-      if (
-        typeof p === 'string' &&
-        !p.endsWith('id') &&
-        !p.endsWith('Id') &&
-        !p.endsWith('ID')
-      ) {
-        throw new Error(\`Path segment "\${p}" does not exist\`);
+      if (Object.hasOwnProperty.call(spec, p)) {
+        return (spec as any)[p];
       }
 
-      return handler;
+      throw new Error(\`Path segment "\${p.toString()}" does not exist\`);
     },
-  }) as ProxyPathParameter<Key, T>;
+  }) as any;
 }
 "
 `;
@@ -413,7 +447,7 @@ export function createSdkClient(options: SdkOptions) {
     request(options: AxiosRequestConfig) {
       return requester.request(options);
     },
-    user_roles: proxyPathParameter('role_id', {
+    user_roles: proxyPathParameter(['role_id'] as const, {
       role_id: (role_id: number | string) => ({
         get(
           query?: any,
@@ -431,34 +465,51 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-type ProxyPathParameter<
-  Key extends string,
-  T extends { [K in Key]: (...args: any) => any },
-> = T & T[Key] & { [K in \`\${string}\${'id' | 'Id' | 'ID'}\`]: T[Key] };
+type ProxyPathParameters<
+  Keys extends readonly string[],
+  Spec extends {
+    [K in Keys[number]]: (...args: any) => any;
+  },
+> = Omit<Spec, Keys[number]> &
+  MergePathParameters<Keys, Spec> & {
+    [K in Keys[number]]: MergePathParameters<Keys, Spec>;
+  };
+
+type MergePathParameters<
+  Keys extends readonly string[],
+  Spec extends {
+    [K in Keys[number]]: (...args: any) => any;
+  },
+> = (
+  ...args: Parameters<Spec[Keys[0]]>
+) => (Keys[0] extends keyof Spec ? ReturnType<Spec[Keys[0]]> : {}) &
+  (Keys[1] extends keyof Spec ? ReturnType<Spec[Keys[1]]> : {}) &
+  (Keys[2] extends keyof Spec ? ReturnType<Spec[Keys[2]]> : {});
 
 function proxyPathParameter<
-  Key extends string,
-  T extends { [K in Key]: (...args: any) => any },
->(key: Key, node: T): ProxyPathParameter<Key, T> {
-  const handler = node[key];
+  Keys extends readonly string[],
+  Spec extends {
+    [K in Keys[number]]: (...args: any) => any;
+  },
+>(keys: Keys, spec: Spec): ProxyPathParameters<Keys, Spec> {
+  const handler = (...args: unknown[]) => {
+    const specs = keys.map((k: Keys[number]) => spec[k](...args));
+    // TODO: deep merge here
+    return Object.assign({}, ...specs);
+  };
   return new Proxy(handler, {
     get(target, p) {
-      if (Object.hasOwnProperty.call(node, p)) {
-        return (node as any)[p];
+      if (typeof p === 'string' && keys.includes(p)) {
+        return handler;
       }
 
-      if (
-        typeof p === 'string' &&
-        !p.endsWith('id') &&
-        !p.endsWith('Id') &&
-        !p.endsWith('ID')
-      ) {
-        throw new Error(\`Path segment "\${p}" does not exist\`);
+      if (Object.hasOwnProperty.call(spec, p)) {
+        return (spec as any)[p];
       }
 
-      return handler;
+      throw new Error(\`Path segment "\${p.toString()}" does not exist\`);
     },
-  }) as ProxyPathParameter<Key, T>;
+  }) as any;
 }
 "
 `;
@@ -543,13 +594,24 @@ export function createSdkClient(options: SdkOptions) {
     request(options: AxiosRequestConfig) {
       return requester.request(options);
     },
-    pets: proxyPathParameter('id', {
+    pets: proxyPathParameter(['id', 'petId'] as const, {
       id: (id: number | string) => ({
         get(query?: any, requestOptions?: RequestOptions): Promise<types.Pet> {
           return requester.get(\`/pets/\${id}\`, query, requestOptions);
         },
         delete(data: any = {}, requestOptions?: RequestOptions): Promise<any> {
           return requester.delete(\`/pets/\${id}\`, data, requestOptions);
+        },
+      }),
+      petId: (petId: number | string) => ({
+        siblings: {
+          get(query?: any, requestOptions?: RequestOptions): Promise<any> {
+            return requester.get(
+              \`/pets/\${petId}/siblings\`,
+              query,
+              requestOptions,
+            );
+          },
         },
       }),
       get(
@@ -573,34 +635,51 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-type ProxyPathParameter<
-  Key extends string,
-  T extends { [K in Key]: (...args: any) => any },
-> = T & T[Key] & { [K in \`\${string}\${'id' | 'Id' | 'ID'}\`]: T[Key] };
+type ProxyPathParameters<
+  Keys extends readonly string[],
+  Spec extends {
+    [K in Keys[number]]: (...args: any) => any;
+  },
+> = Omit<Spec, Keys[number]> &
+  MergePathParameters<Keys, Spec> & {
+    [K in Keys[number]]: MergePathParameters<Keys, Spec>;
+  };
+
+type MergePathParameters<
+  Keys extends readonly string[],
+  Spec extends {
+    [K in Keys[number]]: (...args: any) => any;
+  },
+> = (
+  ...args: Parameters<Spec[Keys[0]]>
+) => (Keys[0] extends keyof Spec ? ReturnType<Spec[Keys[0]]> : {}) &
+  (Keys[1] extends keyof Spec ? ReturnType<Spec[Keys[1]]> : {}) &
+  (Keys[2] extends keyof Spec ? ReturnType<Spec[Keys[2]]> : {});
 
 function proxyPathParameter<
-  Key extends string,
-  T extends { [K in Key]: (...args: any) => any },
->(key: Key, node: T): ProxyPathParameter<Key, T> {
-  const handler = node[key];
+  Keys extends readonly string[],
+  Spec extends {
+    [K in Keys[number]]: (...args: any) => any;
+  },
+>(keys: Keys, spec: Spec): ProxyPathParameters<Keys, Spec> {
+  const handler = (...args: unknown[]) => {
+    const specs = keys.map((k: Keys[number]) => spec[k](...args));
+    // TODO: deep merge here
+    return Object.assign({}, ...specs);
+  };
   return new Proxy(handler, {
     get(target, p) {
-      if (Object.hasOwnProperty.call(node, p)) {
-        return (node as any)[p];
+      if (typeof p === 'string' && keys.includes(p)) {
+        return handler;
       }
 
-      if (
-        typeof p === 'string' &&
-        !p.endsWith('id') &&
-        !p.endsWith('Id') &&
-        !p.endsWith('ID')
-      ) {
-        throw new Error(\`Path segment "\${p}" does not exist\`);
+      if (Object.hasOwnProperty.call(spec, p)) {
+        return (spec as any)[p];
       }
 
-      return handler;
+      throw new Error(\`Path segment "\${p.toString()}" does not exist\`);
     },
-  }) as ProxyPathParameter<Key, T>;
+  }) as any;
 }
 "
 `;
@@ -752,34 +831,51 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-type ProxyPathParameter<
-  Key extends string,
-  T extends { [K in Key]: (...args: any) => any },
-> = T & T[Key] & { [K in \`\${string}\${'id' | 'Id' | 'ID'}\`]: T[Key] };
+type ProxyPathParameters<
+  Keys extends readonly string[],
+  Spec extends {
+    [K in Keys[number]]: (...args: any) => any;
+  },
+> = Omit<Spec, Keys[number]> &
+  MergePathParameters<Keys, Spec> & {
+    [K in Keys[number]]: MergePathParameters<Keys, Spec>;
+  };
+
+type MergePathParameters<
+  Keys extends readonly string[],
+  Spec extends {
+    [K in Keys[number]]: (...args: any) => any;
+  },
+> = (
+  ...args: Parameters<Spec[Keys[0]]>
+) => (Keys[0] extends keyof Spec ? ReturnType<Spec[Keys[0]]> : {}) &
+  (Keys[1] extends keyof Spec ? ReturnType<Spec[Keys[1]]> : {}) &
+  (Keys[2] extends keyof Spec ? ReturnType<Spec[Keys[2]]> : {});
 
 function proxyPathParameter<
-  Key extends string,
-  T extends { [K in Key]: (...args: any) => any },
->(key: Key, node: T): ProxyPathParameter<Key, T> {
-  const handler = node[key];
+  Keys extends readonly string[],
+  Spec extends {
+    [K in Keys[number]]: (...args: any) => any;
+  },
+>(keys: Keys, spec: Spec): ProxyPathParameters<Keys, Spec> {
+  const handler = (...args: unknown[]) => {
+    const specs = keys.map((k: Keys[number]) => spec[k](...args));
+    // TODO: deep merge here
+    return Object.assign({}, ...specs);
+  };
   return new Proxy(handler, {
     get(target, p) {
-      if (Object.hasOwnProperty.call(node, p)) {
-        return (node as any)[p];
+      if (typeof p === 'string' && keys.includes(p)) {
+        return handler;
       }
 
-      if (
-        typeof p === 'string' &&
-        !p.endsWith('id') &&
-        !p.endsWith('Id') &&
-        !p.endsWith('ID')
-      ) {
-        throw new Error(\`Path segment "\${p}" does not exist\`);
+      if (Object.hasOwnProperty.call(spec, p)) {
+        return (spec as any)[p];
       }
 
-      return handler;
+      throw new Error(\`Path segment "\${p.toString()}" does not exist\`);
     },
-  }) as ProxyPathParameter<Key, T>;
+  }) as any;
 }
 "
 `;

--- a/src/tests/__snapshots__/generator.test.ts.snap
+++ b/src/tests/__snapshots__/generator.test.ts.snap
@@ -40,14 +40,14 @@ export function createSdkClient(options: SdkOptions) {
       return requester.request(options);
     },
     billing: {
-      invoices: proxyPathParameter(['id'] as const, {
-        id: (id: number | string) => ({
+      invoices: withPathParameters(['id'] as const, {
+        pathParameter: (pathParameter: number | string) => ({
           get(
             query?: any,
             requestOptions?: RequestOptions,
-          ): Promise<types.AgGetBillingInvoicesByIdResponse> {
+          ): Promise<types.AgGetBillingInvoicesByPathParameterResponse> {
             return requester.get(
-              \`/billing/invoices/\${id}\`,
+              \`/billing/invoices/\${pathParameter}\`,
               query,
               requestOptions,
             );
@@ -71,57 +71,37 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-type ProxyPathParameters<
+type WithPathParameters<
   Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
-> = Omit<Spec, Keys[number]> &
-  MergePathParameters<Keys, Spec> & {
-    [K in Keys[number]]: MergePathParameters<Keys, Spec>;
+  Spec extends { pathParameter: (...args: any) => any },
+> = Spec['pathParameter'] &
+  Omit<Spec, 'pathParameter'> & {
+    [K in Keys[number]]: Spec['pathParameter'];
   };
 
-type MergePathParameters<
+function withPathParameters<
   Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
-> = (
-  ...args: Parameters<Spec[Keys[0]]>
-) => (Keys[0] extends keyof Spec ? ReturnType<Spec[Keys[0]]> : {}) &
-  (Keys[1] extends keyof Spec ? ReturnType<Spec[Keys[1]]> : {}) &
-  (Keys[2] extends keyof Spec ? ReturnType<Spec[Keys[2]]> : {});
-
-function proxyPathParameter<
-  Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
->(keys: Keys, spec: Spec): ProxyPathParameters<Keys, Spec> {
-  const handler = (...args: unknown[]) => {
-    const specs = keys.map((k: Keys[number]) => spec[k](...args));
-    // TODO: deep merge here
-    return Object.assign({}, ...specs);
-  };
-  return new Proxy(handler, {
-    get(target, p) {
-      if (typeof p === 'string' && keys.includes(p)) {
-        return handler;
+  Spec extends { pathParameter: (...args: any) => any },
+>(keys: Keys, spec: Spec): WithPathParameters<Keys, Spec> {
+  return new Proxy(spec.pathParameter, {
+    get(target, key) {
+      if (typeof key === 'string' && keys.includes(key)) {
+        return spec.pathParameter;
       }
 
-      if (Object.hasOwnProperty.call(spec, p)) {
-        return (spec as any)[p];
+      if (key !== 'pathParameter' && Object.hasOwnProperty.call(spec, key)) {
+        return spec[key as keyof Spec];
       }
 
-      throw new Error(\`Path segment "\${p.toString()}" does not exist\`);
+      throw new Error('Path segment "' + key.toString() + '" does not exist');
     },
-  }) as any;
+  }) as WithPathParameters<Keys, Spec>;
 }
 "
 `;
 
 exports[`Anonymous Types 2`] = `
-"export interface AgGetBillingInvoicesByIdResponse {
+"export interface AgGetBillingInvoicesByPathParameterResponse {
   invoice: {
     id: number;
   };
@@ -188,15 +168,15 @@ export function createSdkClient(options: SdkOptions) {
     request(options: AxiosRequestConfig) {
       return requester.request(options);
     },
-    companies: proxyPathParameter(['id'] as const, {
-      id: (id: number | string) => ({
+    companies: withPathParameters(['id'] as const, {
+      pathParameter: (pathParameter: number | string) => ({
         archive: {
           post(
             data: any = {},
             requestOptions?: RequestOptions,
           ): Promise<types.SuccessResponse> {
             return requester.post(
-              \`/companies/\${id}/archive\`,
+              \`/companies/\${pathParameter}/archive\`,
               data,
               requestOptions,
             );
@@ -206,19 +186,31 @@ export function createSdkClient(options: SdkOptions) {
           query?: any,
           requestOptions?: RequestOptions,
         ): Promise<types.CompanyResponse> {
-          return requester.get(\`/companies/\${id}\`, query, requestOptions);
+          return requester.get(
+            \`/companies/\${pathParameter}\`,
+            query,
+            requestOptions,
+          );
         },
         patch(
           data: types.CompanyUpdateRequest,
           requestOptions?: RequestOptions,
         ): Promise<types.CompanyResponse> {
-          return requester.patch(\`/companies/\${id}\`, data, requestOptions);
+          return requester.patch(
+            \`/companies/\${pathParameter}\`,
+            data,
+            requestOptions,
+          );
         },
         delete(
           data: any = {},
           requestOptions?: RequestOptions,
         ): Promise<types.SuccessResponse> {
-          return requester.delete(\`/companies/\${id}\`, data, requestOptions);
+          return requester.delete(
+            \`/companies/\${pathParameter}\`,
+            data,
+            requestOptions,
+          );
         },
       }),
       get(
@@ -242,51 +234,31 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-type ProxyPathParameters<
+type WithPathParameters<
   Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
-> = Omit<Spec, Keys[number]> &
-  MergePathParameters<Keys, Spec> & {
-    [K in Keys[number]]: MergePathParameters<Keys, Spec>;
+  Spec extends { pathParameter: (...args: any) => any },
+> = Spec['pathParameter'] &
+  Omit<Spec, 'pathParameter'> & {
+    [K in Keys[number]]: Spec['pathParameter'];
   };
 
-type MergePathParameters<
+function withPathParameters<
   Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
-> = (
-  ...args: Parameters<Spec[Keys[0]]>
-) => (Keys[0] extends keyof Spec ? ReturnType<Spec[Keys[0]]> : {}) &
-  (Keys[1] extends keyof Spec ? ReturnType<Spec[Keys[1]]> : {}) &
-  (Keys[2] extends keyof Spec ? ReturnType<Spec[Keys[2]]> : {});
-
-function proxyPathParameter<
-  Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
->(keys: Keys, spec: Spec): ProxyPathParameters<Keys, Spec> {
-  const handler = (...args: unknown[]) => {
-    const specs = keys.map((k: Keys[number]) => spec[k](...args));
-    // TODO: deep merge here
-    return Object.assign({}, ...specs);
-  };
-  return new Proxy(handler, {
-    get(target, p) {
-      if (typeof p === 'string' && keys.includes(p)) {
-        return handler;
+  Spec extends { pathParameter: (...args: any) => any },
+>(keys: Keys, spec: Spec): WithPathParameters<Keys, Spec> {
+  return new Proxy(spec.pathParameter, {
+    get(target, key) {
+      if (typeof key === 'string' && keys.includes(key)) {
+        return spec.pathParameter;
       }
 
-      if (Object.hasOwnProperty.call(spec, p)) {
-        return (spec as any)[p];
+      if (key !== 'pathParameter' && Object.hasOwnProperty.call(spec, key)) {
+        return spec[key as keyof Spec];
       }
 
-      throw new Error(\`Path segment "\${p.toString()}" does not exist\`);
+      throw new Error('Path segment "' + key.toString() + '" does not exist');
     },
-  }) as any;
+  }) as WithPathParameters<Keys, Spec>;
 }
 "
 `;
@@ -447,13 +419,17 @@ export function createSdkClient(options: SdkOptions) {
     request(options: AxiosRequestConfig) {
       return requester.request(options);
     },
-    user_roles: proxyPathParameter(['role_id'] as const, {
-      role_id: (role_id: number | string) => ({
+    user_roles: withPathParameters(['role_id'] as const, {
+      pathParameter: (pathParameter: number | string) => ({
         get(
           query?: any,
           requestOptions?: RequestOptions,
-        ): Promise<types.AgGetUserRolesByRoleIdResponse> {
-          return requester.get(\`/user-roles/\${role_id}\`, query, requestOptions);
+        ): Promise<types.AgGetUserRolesByPathParameterResponse> {
+          return requester.get(
+            \`/user-roles/\${pathParameter}\`,
+            query,
+            requestOptions,
+          );
         },
       }),
     }),
@@ -465,57 +441,37 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-type ProxyPathParameters<
+type WithPathParameters<
   Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
-> = Omit<Spec, Keys[number]> &
-  MergePathParameters<Keys, Spec> & {
-    [K in Keys[number]]: MergePathParameters<Keys, Spec>;
+  Spec extends { pathParameter: (...args: any) => any },
+> = Spec['pathParameter'] &
+  Omit<Spec, 'pathParameter'> & {
+    [K in Keys[number]]: Spec['pathParameter'];
   };
 
-type MergePathParameters<
+function withPathParameters<
   Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
-> = (
-  ...args: Parameters<Spec[Keys[0]]>
-) => (Keys[0] extends keyof Spec ? ReturnType<Spec[Keys[0]]> : {}) &
-  (Keys[1] extends keyof Spec ? ReturnType<Spec[Keys[1]]> : {}) &
-  (Keys[2] extends keyof Spec ? ReturnType<Spec[Keys[2]]> : {});
-
-function proxyPathParameter<
-  Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
->(keys: Keys, spec: Spec): ProxyPathParameters<Keys, Spec> {
-  const handler = (...args: unknown[]) => {
-    const specs = keys.map((k: Keys[number]) => spec[k](...args));
-    // TODO: deep merge here
-    return Object.assign({}, ...specs);
-  };
-  return new Proxy(handler, {
-    get(target, p) {
-      if (typeof p === 'string' && keys.includes(p)) {
-        return handler;
+  Spec extends { pathParameter: (...args: any) => any },
+>(keys: Keys, spec: Spec): WithPathParameters<Keys, Spec> {
+  return new Proxy(spec.pathParameter, {
+    get(target, key) {
+      if (typeof key === 'string' && keys.includes(key)) {
+        return spec.pathParameter;
       }
 
-      if (Object.hasOwnProperty.call(spec, p)) {
-        return (spec as any)[p];
+      if (key !== 'pathParameter' && Object.hasOwnProperty.call(spec, key)) {
+        return spec[key as keyof Spec];
       }
 
-      throw new Error(\`Path segment "\${p.toString()}" does not exist\`);
+      throw new Error('Path segment "' + key.toString() + '" does not exist');
     },
-  }) as any;
+  }) as WithPathParameters<Keys, Spec>;
 }
 "
 `;
 
 exports[`Dashes and Underscores 2`] = `
-"export interface AgGetUserRolesByRoleIdResponse {
+"export interface AgGetUserRolesByPathParameterResponse {
   user_role: UserRole;
 }
 export interface UserRole {
@@ -594,24 +550,26 @@ export function createSdkClient(options: SdkOptions) {
     request(options: AxiosRequestConfig) {
       return requester.request(options);
     },
-    pets: proxyPathParameter(['id', 'petId'] as const, {
-      id: (id: number | string) => ({
-        get(query?: any, requestOptions?: RequestOptions): Promise<types.Pet> {
-          return requester.get(\`/pets/\${id}\`, query, requestOptions);
-        },
-        delete(data: any = {}, requestOptions?: RequestOptions): Promise<any> {
-          return requester.delete(\`/pets/\${id}\`, data, requestOptions);
-        },
-      }),
-      petId: (petId: number | string) => ({
+    pets: withPathParameters(['id', 'petId'] as const, {
+      pathParameter: (pathParameter: number | string) => ({
         siblings: {
           get(query?: any, requestOptions?: RequestOptions): Promise<any> {
             return requester.get(
-              \`/pets/\${petId}/siblings\`,
+              \`/pets/\${pathParameter}/siblings\`,
               query,
               requestOptions,
             );
           },
+        },
+        get(query?: any, requestOptions?: RequestOptions): Promise<types.Pet> {
+          return requester.get(\`/pets/\${pathParameter}\`, query, requestOptions);
+        },
+        delete(data: any = {}, requestOptions?: RequestOptions): Promise<any> {
+          return requester.delete(
+            \`/pets/\${pathParameter}\`,
+            data,
+            requestOptions,
+          );
         },
       }),
       get(
@@ -635,51 +593,31 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-type ProxyPathParameters<
+type WithPathParameters<
   Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
-> = Omit<Spec, Keys[number]> &
-  MergePathParameters<Keys, Spec> & {
-    [K in Keys[number]]: MergePathParameters<Keys, Spec>;
+  Spec extends { pathParameter: (...args: any) => any },
+> = Spec['pathParameter'] &
+  Omit<Spec, 'pathParameter'> & {
+    [K in Keys[number]]: Spec['pathParameter'];
   };
 
-type MergePathParameters<
+function withPathParameters<
   Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
-> = (
-  ...args: Parameters<Spec[Keys[0]]>
-) => (Keys[0] extends keyof Spec ? ReturnType<Spec[Keys[0]]> : {}) &
-  (Keys[1] extends keyof Spec ? ReturnType<Spec[Keys[1]]> : {}) &
-  (Keys[2] extends keyof Spec ? ReturnType<Spec[Keys[2]]> : {});
-
-function proxyPathParameter<
-  Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
->(keys: Keys, spec: Spec): ProxyPathParameters<Keys, Spec> {
-  const handler = (...args: unknown[]) => {
-    const specs = keys.map((k: Keys[number]) => spec[k](...args));
-    // TODO: deep merge here
-    return Object.assign({}, ...specs);
-  };
-  return new Proxy(handler, {
-    get(target, p) {
-      if (typeof p === 'string' && keys.includes(p)) {
-        return handler;
+  Spec extends { pathParameter: (...args: any) => any },
+>(keys: Keys, spec: Spec): WithPathParameters<Keys, Spec> {
+  return new Proxy(spec.pathParameter, {
+    get(target, key) {
+      if (typeof key === 'string' && keys.includes(key)) {
+        return spec.pathParameter;
       }
 
-      if (Object.hasOwnProperty.call(spec, p)) {
-        return (spec as any)[p];
+      if (key !== 'pathParameter' && Object.hasOwnProperty.call(spec, key)) {
+        return spec[key as keyof Spec];
       }
 
-      throw new Error(\`Path segment "\${p.toString()}" does not exist\`);
+      throw new Error('Path segment "' + key.toString() + '" does not exist');
     },
-  }) as any;
+  }) as WithPathParameters<Keys, Spec>;
 }
 "
 `;
@@ -831,51 +769,31 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-type ProxyPathParameters<
+type WithPathParameters<
   Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
-> = Omit<Spec, Keys[number]> &
-  MergePathParameters<Keys, Spec> & {
-    [K in Keys[number]]: MergePathParameters<Keys, Spec>;
+  Spec extends { pathParameter: (...args: any) => any },
+> = Spec['pathParameter'] &
+  Omit<Spec, 'pathParameter'> & {
+    [K in Keys[number]]: Spec['pathParameter'];
   };
 
-type MergePathParameters<
+function withPathParameters<
   Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
-> = (
-  ...args: Parameters<Spec[Keys[0]]>
-) => (Keys[0] extends keyof Spec ? ReturnType<Spec[Keys[0]]> : {}) &
-  (Keys[1] extends keyof Spec ? ReturnType<Spec[Keys[1]]> : {}) &
-  (Keys[2] extends keyof Spec ? ReturnType<Spec[Keys[2]]> : {});
-
-function proxyPathParameter<
-  Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
->(keys: Keys, spec: Spec): ProxyPathParameters<Keys, Spec> {
-  const handler = (...args: unknown[]) => {
-    const specs = keys.map((k: Keys[number]) => spec[k](...args));
-    // TODO: deep merge here
-    return Object.assign({}, ...specs);
-  };
-  return new Proxy(handler, {
-    get(target, p) {
-      if (typeof p === 'string' && keys.includes(p)) {
-        return handler;
+  Spec extends { pathParameter: (...args: any) => any },
+>(keys: Keys, spec: Spec): WithPathParameters<Keys, Spec> {
+  return new Proxy(spec.pathParameter, {
+    get(target, key) {
+      if (typeof key === 'string' && keys.includes(key)) {
+        return spec.pathParameter;
       }
 
-      if (Object.hasOwnProperty.call(spec, p)) {
-        return (spec as any)[p];
+      if (key !== 'pathParameter' && Object.hasOwnProperty.call(spec, key)) {
+        return spec[key as keyof Spec];
       }
 
-      throw new Error(\`Path segment "\${p.toString()}" does not exist\`);
+      throw new Error('Path segment "' + key.toString() + '" does not exist');
     },
-  }) as any;
+  }) as WithPathParameters<Keys, Spec>;
 }
 "
 `;
@@ -939,7 +857,7 @@ Object.keys(schemas).forEach((name) => {
 exports[`Schema Prefix 1`] = `
 "export const schemas = {
   User: {} as any,
-  AgGetUsersByIdResponse: {} as any,
+  AgGetUsersByPathParameterResponse: {} as any,
 };
 
 schemas.User = Object.assign(schemas.User, {
@@ -948,11 +866,10 @@ schemas.User = Object.assign(schemas.User, {
   required: ['id', 'name'],
 });
 
-schemas.AgGetUsersByIdResponse = Object.assign(schemas.AgGetUsersByIdResponse, {
-  type: 'object',
-  properties: { user: schemas.User },
-  required: ['user'],
-});
+schemas.AgGetUsersByPathParameterResponse = Object.assign(
+  schemas.AgGetUsersByPathParameterResponse,
+  { type: 'object', properties: { user: schemas.User }, required: ['user'] },
+);
 
 Object.keys(schemas).forEach((name) => {
   schemas[name as keyof typeof schemas].$id = 'myFancyPrefix_' + name;
@@ -968,7 +885,8 @@ export interface SdkSchema<T> extends JSONSchema6 {
 }
 export const schemas = {
   User: {} as SdkSchema<types.User>,
-  AgGetUsersByIdResponse: {} as SdkSchema<types.AgGetUsersByIdResponse>,
+  AgGetUsersByPathParameterResponse:
+    {} as SdkSchema<types.AgGetUsersByPathParameterResponse>,
 };
 
 schemas.User = Object.assign(schemas.User, {
@@ -977,11 +895,10 @@ schemas.User = Object.assign(schemas.User, {
   required: ['id', 'name'],
 });
 
-schemas.AgGetUsersByIdResponse = Object.assign(schemas.AgGetUsersByIdResponse, {
-  type: 'object',
-  properties: { user: schemas.User },
-  required: ['user'],
-});
+schemas.AgGetUsersByPathParameterResponse = Object.assign(
+  schemas.AgGetUsersByPathParameterResponse,
+  { type: 'object', properties: { user: schemas.User }, required: ['user'] },
+);
 
 Object.keys(schemas).forEach((name) => {
   schemas[name as keyof typeof schemas].$id = 'default_' + name;

--- a/src/tests/assets/openapi-v3/petstore.json
+++ b/src/tests/assets/openapi-v3/petstore.json
@@ -168,6 +168,48 @@
           }
         }
       }
+    },
+    "/pets/{petId}/siblings": {
+      "get": {
+        "operationId": "find pet siblings by pet id",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to fetch siblings of",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/template/sdkClient.ts
+++ b/template/sdkClient.ts
@@ -45,49 +45,29 @@ export type SdkClient = ReturnType<typeof createSdkClient>;
 export const CancelToken = axios.CancelToken;
 export const isCancel = axios.isCancel;
 
-type ProxyPathParameters<
+type WithPathParameters<
   Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
-> = Omit<Spec, Keys[number]> &
-  MergePathParameters<Keys, Spec> & {
-    [K in Keys[number]]: MergePathParameters<Keys, Spec>;
+  Spec extends { pathParameter: (...args: any) => any },
+> = Spec['pathParameter'] &
+  Omit<Spec, 'pathParameter'> & {
+    [K in Keys[number]]: Spec['pathParameter'];
   };
 
-type MergePathParameters<
+function withPathParameters<
   Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
-> = (
-  ...args: Parameters<Spec[Keys[0]]>
-) => (Keys[0] extends keyof Spec ? ReturnType<Spec[Keys[0]]> : {}) &
-  (Keys[1] extends keyof Spec ? ReturnType<Spec[Keys[1]]> : {}) &
-  (Keys[2] extends keyof Spec ? ReturnType<Spec[Keys[2]]> : {});
-
-function proxyPathParameter<
-  Keys extends readonly string[],
-  Spec extends {
-    [K in Keys[number]]: (...args: any) => any;
-  },
->(keys: Keys, spec: Spec): ProxyPathParameters<Keys, Spec> {
-  const handler = (...args: unknown[]) => {
-    const specs = keys.map((k: Keys[number]) => spec[k](...args));
-    // TODO: deep merge here
-    return Object.assign({}, ...specs);
-  };
-  return new Proxy(handler, {
-    get(target, p) {
-      if (typeof p === 'string' && keys.includes(p)) {
-        return handler;
+  Spec extends { pathParameter: (...args: any) => any },
+>(keys: Keys, spec: Spec): WithPathParameters<Keys, Spec> {
+  return new Proxy(spec.pathParameter, {
+    get(target, key) {
+      if (typeof key === 'string' && keys.includes(key)) {
+        return spec.pathParameter;
       }
 
-      if (Object.hasOwnProperty.call(spec, p)) {
-        return (spec as any)[p];
+      if (key !== 'pathParameter' && Object.hasOwnProperty.call(spec, key)) {
+        return spec[key as keyof Spec];
       }
 
-      throw new Error(\`Path segment "\${p.toString()}" does not exist\`);
+      throw new Error('Path segment "' + key.toString() + '" does not exist');
     },
-  }) as any;
+  }) as WithPathParameters<Keys, Spec>;
 }

--- a/template/sdkClient.ts
+++ b/template/sdkClient.ts
@@ -87,7 +87,7 @@ function proxyPathParameter<
         return (spec as any)[p];
       }
 
-      throw new Error(`Path segment "${p.toString()}" does not exist`);
+      throw new Error(\`Path segment "\${p.toString()}" does not exist\`);
     },
   }) as any;
 }


### PR DESCRIPTION
Given the following URLs in spec:

```
GET pets/{id}
DELETE pets/{id}
GET pets/{petId}/siblings
```

Generates the client that supports all of the following:

```ts
client.pets(1).get();
client.pets.id(1).get();
client.pets.id(1).siblings.get();
client.pets.petId(1).get();
client.pets.petId(1).siblings.get();

// Not allowed:
client.pets.unknownId(1).siblings.get();
```

This implementation supports a maximum of three merged path parameter names.