### PR TITLE
Always allow "id" path parameter

### DIFF
--- a/src/specReader.ts
+++ b/src/specReader.ts
@@ -151,10 +151,14 @@ function createRegularNode(parent: SdkNode, name: string): SdkRegularNode {
 }
 
 function createFunctionNode(parent: SdkNode, name: string): SdkFunctionNode {
+  const aliases = [name];
+  if (name !== 'id') {
+    aliases.push('id');
+  }
   return {
     parent,
     name,
-    aliases: [name],
+    aliases,
     isFunction: true,
     children: {},
     methods: {},

--- a/src/tests/__snapshots__/generator.test.ts.snap
+++ b/src/tests/__snapshots__/generator.test.ts.snap
@@ -585,48 +585,6 @@ function withPathParameters<
 "
 `;
 
-exports[`Id Path Parameter 2`] = `
-"export interface Company {
-  id: number;
-  name: string;
-  size: number;
-  meta?: {};
-}
-export interface CompanyResponse {
-  company: Company;
-}
-"
-`;
-
-exports[`Id Path Parameter 3`] = `
-"export const schemas = {
-  Company: {} as any,
-  CompanyResponse: {} as any,
-};
-
-schemas.Company = Object.assign(schemas.Company, {
-  type: 'object',
-  properties: {
-    id: { type: 'integer' },
-    name: { type: 'string' },
-    size: { type: 'integer' },
-    meta: { type: 'object' },
-  },
-  required: ['id', 'name', 'size'],
-});
-
-schemas.CompanyResponse = Object.assign(schemas.CompanyResponse, {
-  type: 'object',
-  properties: { company: schemas.Company },
-  required: ['company'],
-});
-
-Object.keys(schemas).forEach((name) => {
-  schemas[name as keyof typeof schemas].$id = 'default_' + name;
-});
-"
-`;
-
 exports[`OpenAPI V3 Basic Scenario 1`] = `
 "import axios, { AxiosRequestConfig, AxiosError } from 'axios';
 

--- a/src/tests/__snapshots__/generator.test.ts.snap
+++ b/src/tests/__snapshots__/generator.test.ts.snap
@@ -407,7 +407,7 @@ export function createSdkClient(options: SdkOptions) {
     request(options: AxiosRequestConfig) {
       return requester.request(options);
     },
-    user_roles: withPathParameters(['role_id'] as const, {
+    user_roles: withPathParameters(['role_id', 'id'] as const, {
       pathParameter: (role_id: number | string) => ({
         get(
           query?: any,
@@ -492,6 +492,138 @@ export enum ProcessDefinitionKey {
   csIncorporationPteLtdLocal = 'cs-incorporation-pte-ltd-local',
   csAppointmentOfNewSecretary = 'cs-appointment-of-new-secretary',
 }
+"
+`;
+
+exports[`Id Path Parameter 1`] = `
+"import axios, { AxiosRequestConfig, AxiosError } from 'axios';
+
+import { RequestOptions, SdkOptions } from './options';
+import { SdkRequester } from './requester';
+import * as types from './types';
+
+export function createSdkClient(options: SdkOptions) {
+  const requester = new SdkRequester(options);
+  return {
+    setAuthToken(authToken: string | undefined | null) {
+      requester.setAuthToken(authToken);
+    },
+    setErrorHandler(handler: (error: AxiosError) => void) {
+      requester.setErrorHandler(handler);
+    },
+    setInterceptors(
+      interceptors: Parameters<typeof requester.setInterceptors>[0],
+    ) {
+      requester.setInterceptors(interceptors);
+    },
+    get(path: string, query?: object, requestOptions?: RequestOptions) {
+      return requester.get(path, query, requestOptions);
+    },
+    post(path: string, data?: object, requestOptions?: RequestOptions) {
+      return requester.post(path, data, requestOptions);
+    },
+    put(path: string, data?: object, requestOptions?: RequestOptions) {
+      return requester.put(path, data, requestOptions);
+    },
+    patch(path: string, data?: object, requestOptions?: RequestOptions) {
+      return requester.patch(path, data, requestOptions);
+    },
+    delete(path: string, data?: object, requestOptions?: RequestOptions) {
+      return requester.delete(path, data, requestOptions);
+    },
+    request(options: AxiosRequestConfig) {
+      return requester.request(options);
+    },
+    companies: withPathParameters(['companyId', 'id'] as const, {
+      pathParameter: (companyId: number | string) => ({
+        get(
+          query?: any,
+          requestOptions?: RequestOptions,
+        ): Promise<types.CompanyResponse> {
+          return requester.get(
+            \`/companies/\${companyId}\`,
+            query,
+            requestOptions,
+          );
+        },
+      }),
+    }),
+  };
+}
+
+export type SdkClient = ReturnType<typeof createSdkClient>;
+
+export const CancelToken = axios.CancelToken;
+export const isCancel = axios.isCancel;
+
+type WithPathParameters<
+  Keys extends readonly string[],
+  Spec extends { pathParameter: (...args: any) => any },
+> = Spec['pathParameter'] &
+  Omit<Spec, 'pathParameter'> & {
+    [K in Keys[number]]: Spec['pathParameter'];
+  };
+
+function withPathParameters<
+  Keys extends readonly string[],
+  Spec extends { pathParameter: (...args: any) => any },
+>(keys: Keys, spec: Spec): WithPathParameters<Keys, Spec> {
+  return new Proxy(spec.pathParameter, {
+    get(target, key) {
+      if (typeof key === 'string' && keys.includes(key)) {
+        return spec.pathParameter;
+      }
+
+      if (key !== 'pathParameter' && Object.hasOwnProperty.call(spec, key)) {
+        return spec[key as keyof Spec];
+      }
+
+      throw new Error('Path segment "' + key.toString() + '" does not exist');
+    },
+  }) as WithPathParameters<Keys, Spec>;
+}
+"
+`;
+
+exports[`Id Path Parameter 2`] = `
+"export interface Company {
+  id: number;
+  name: string;
+  size: number;
+  meta?: {};
+}
+export interface CompanyResponse {
+  company: Company;
+}
+"
+`;
+
+exports[`Id Path Parameter 3`] = `
+"export const schemas = {
+  Company: {} as any,
+  CompanyResponse: {} as any,
+};
+
+schemas.Company = Object.assign(schemas.Company, {
+  type: 'object',
+  properties: {
+    id: { type: 'integer' },
+    name: { type: 'string' },
+    size: { type: 'integer' },
+    meta: { type: 'object' },
+  },
+  required: ['id', 'name', 'size'],
+});
+
+schemas.CompanyResponse = Object.assign(schemas.CompanyResponse, {
+  type: 'object',
+  properties: { company: schemas.Company },
+  required: ['company'],
+});
+
+Object.keys(schemas).forEach((name) => {
+  schemas[name as keyof typeof schemas].$id = 'default_' + name;
+});
 "
 `;
 

--- a/src/tests/generator.test.ts
+++ b/src/tests/generator.test.ts
@@ -127,6 +127,24 @@ it('Schema Prefix', async () => {
   expect(schemasSource).toMatchSnapshot();
 });
 
+it('Id Path Parameter', async () => {
+  const endpoints = `
+    @token GET /companies/:companyId
+      => CompanyResponse
+  `;
+  const models = `
+    Company { id: i, name: s, size: i, meta?: o }
+    CompanyResponse { company: Company }
+  `;
+  const { clientSource, typesSource, schemasSource } = await generate({
+    endpoints,
+    models,
+  });
+  expect(clientSource).toMatchSnapshot();
+  expect(typesSource).toMatchSnapshot();
+  expect(schemasSource).toMatchSnapshot();
+});
+
 it('Typed Schemas', async () => {
   const endpoints = `
     GET /users/:id

--- a/src/tests/generator.test.ts
+++ b/src/tests/generator.test.ts
@@ -136,7 +136,7 @@ it('Id Path Parameter', async () => {
     Company { id: i, name: s, size: i, meta?: o }
     CompanyResponse { company: Company }
   `;
-  const { clientSource, typesSource, schemasSource } = await generate({
+  const { clientSource } = await generate({
     endpoints,
     models,
   });

--- a/src/tests/generator.test.ts
+++ b/src/tests/generator.test.ts
@@ -141,8 +141,6 @@ it('Id Path Parameter', async () => {
     models,
   });
   expect(clientSource).toMatchSnapshot();
-  expect(typesSource).toMatchSnapshot();
-  expect(schemasSource).toMatchSnapshot();
 });
 
 it('Typed Schemas', async () => {


### PR DESCRIPTION
🚂 https://github.com/OsomePteLtd/openapi-ts-sdk/pull/62

`id` path parameter is a special case and we should always allow it.